### PR TITLE
feat: make medialane upgradeable

### DIFF
--- a/contracts/Medialane-Protocol/Scarb.lock
+++ b/contracts/Medialane-Protocol/Scarb.lock
@@ -9,6 +9,7 @@ dependencies = [
  "openzeppelin_account",
  "openzeppelin_introspection",
  "openzeppelin_token",
+ "openzeppelin_upgrades",
  "openzeppelin_utils",
  "snforge_std",
 ]
@@ -49,6 +50,12 @@ dependencies = [
  "openzeppelin_introspection",
  "openzeppelin_utils",
 ]
+
+[[package]]
+name = "openzeppelin_upgrades"
+version = "2.0.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:560d57a9c3f3ec5a476e82fec8963c93c8df63a4ff9ff134f64ab8383bde3c61"
 
 [[package]]
 name = "openzeppelin_utils"

--- a/contracts/Medialane-Protocol/Scarb.toml
+++ b/contracts/Medialane-Protocol/Scarb.toml
@@ -12,6 +12,7 @@ openzeppelin_utils = "2.0.0"
 openzeppelin_access = "2.0.0"
 openzeppelin_introspection = "2.0.0"
 openzeppelin_account = "2.0.0"
+openzeppelin_upgrades = "2.0.0"
 
 [dev-dependencies]
 snforge_std = "0.44.0"

--- a/contracts/Medialane-Protocol/tests/tests.cairo
+++ b/contracts/Medialane-Protocol/tests/tests.cairo
@@ -105,13 +105,16 @@ mod test {
         contract_address
     }
 
-    fn deploy_medialane(native_token: ContractAddress) -> IMedialaneDispatcher {
+    fn deploy_medialane(
+        native_token: ContractAddress, owner_adddress: ContractAddress,
+    ) -> IMedialaneDispatcher {
         let expected_medialane_contract: ContractAddress =
             0x2a0626d1a71fab6c6cdcb262afc48bff92a6844700ebbd16297596e6c53da29
             .try_into()
             .unwrap();
 
         let mut constructor_calldata = array![];
+        owner_adddress.serialize(ref constructor_calldata);
         native_token.serialize(ref constructor_calldata);
         let contract_address = deploy_contract(
             "Medialane", @constructor_calldata, expected_medialane_contract,
@@ -172,7 +175,7 @@ mod test {
     fn setup_contracts_and_accounts() -> (DeployedContracts, Accounts) {
         let accounts = setup_accounts();
         let mut erc20_contract = deploy_erc20(accounts.owner);
-        let medialane_contract = deploy_medialane(erc20_contract.contract_address);
+        let medialane_contract = deploy_medialane(erc20_contract.contract_address, accounts.owner);
         let erc721_contract = deploy_erc721(accounts.owner);
         let erc1155_contract = deploy_erc1155(accounts.owner);
 


### PR DESCRIPTION
Closes #120 

**Upgrade Medialane Contract to Support Upgradeability and Role-Based Access Control**

* Refactored the Medialane contract to be upgradeable.
* Implemented role-based authentication, restricting the upgrade functionality to addresses with the `DEFAULT_ADMIN_ROLE`.
