### PR TITLE
chore: mip code refactor and cleanup

### DIFF
--- a/contracts/MIP-Collections-ERC721/.tool-versions
+++ b/contracts/MIP-Collections-ERC721/.tool-versions
@@ -1,1 +1,2 @@
-scarb 2.9.2
+scarb 2.12.0
+starknet-foundry 0.48.0

--- a/contracts/MIP-Collections-ERC721/Scarb.lock
+++ b/contracts/MIP-Collections-ERC721/Scarb.lock
@@ -117,15 +117,15 @@ source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.20.0#77
 
 [[package]]
 name = "snforge_scarb_plugin"
-version = "0.44.0"
+version = "0.48.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:ec8c7637b33392a53153c1e5b87a4617ddcb1981951b233ea043cad5136697e2"
+checksum = "sha256:8630dcf3fa4df36a3d45e6a2d053cf84c548ab154e829fece99373ae5852921c"
 
 [[package]]
 name = "snforge_std"
-version = "0.44.0"
+version = "0.48.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:d4affedfb90715b1ac417b915c0a63377ae6dd69432040e5d933130d65114702"
+checksum = "sha256:981139c83359089540652c44f4a1a888c77409eedaa148377927cc63a604b67b"
 dependencies = [
  "snforge_scarb_plugin",
 ]

--- a/contracts/MIP-Collections-ERC721/Scarb.toml
+++ b/contracts/MIP-Collections-ERC721/Scarb.toml
@@ -6,12 +6,12 @@ edition = "2024_07"
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 
 [dependencies]
-starknet = "2.9.2"
+starknet = "2.12.0"
 openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.20.0" }
 
 [dev-dependencies]
-snforge_std = "0.44.0"
-assert_macros = "2.9.2"
+snforge_std = "0.48.0"
+assert_macros = "2.12.0"
 
 [[target.starknet-contract]]
 sierra = true

--- a/contracts/MIP-Collections-ERC721/src/interfaces/IIPCollection.cairo
+++ b/contracts/MIP-Collections-ERC721/src/interfaces/IIPCollection.cairo
@@ -1,6 +1,6 @@
 /// Interface for IP Collection contract, defining core collection and token management operations.
-use starknet::ContractAddress;
-use crate::types::{Collection, TokenData, CollectionStats};
+use starknet::{ClassHash, ContractAddress};
+use crate::types::{Collection, CollectionStats, TokenData};
 
 #[starknet::interface]
 pub trait IIPCollection<ContractState> {
@@ -161,4 +161,11 @@ pub trait IIPCollection<ContractState> {
     /// # Returns
     /// `true` if valid, `false` otherwise.
     fn is_valid_token(self: @ContractState, token: ByteArray) -> bool;
+
+    /// Upgrades the collection nft class hash
+    ///
+    /// Params:
+    /// - `new_nft_class_hash`: Class hash of new IP NFT contract
+    ///
+    fn upgrade_ip_nft_class_hash(ref self: ContractState, new_nft_class_hash: ClassHash);
 }

--- a/contracts/MIP-Collections-ERC721/src/interfaces/IIPNFT.cairo
+++ b/contracts/MIP-Collections-ERC721/src/interfaces/IIPNFT.cairo
@@ -1,6 +1,4 @@
 /// Interface for IPNFT (Intellectual Property NFT) contract operations.
-///
-/// Provides standard ERC721-like functionality with additional collection management features.
 use starknet::ContractAddress;
 
 #[starknet::interface]
@@ -21,16 +19,6 @@ pub trait IIPNft<ContractState> {
     /// * `token_id` - The unique identifier for the token to be burned.
     fn burn(ref self: ContractState, token_id: u256);
 
-    /// Transfers the token with `token_id` from one address to another.
-    ///
-    /// # Arguments
-    /// * `from` - The address sending the token.
-    /// * `to` - The address receiving the token.
-    /// * `token_id` - The unique identifier for the token to be transferred.
-    fn transfer(
-        ref self: ContractState, from: ContractAddress, to: ContractAddress, token_id: u256,
-    );
-
     /// Returns the unique identifier of the collection this contract manages.
     ///
     /// # Returns
@@ -42,48 +30,4 @@ pub trait IIPNft<ContractState> {
     /// # Returns
     /// * `ContractAddress` - The address managing the collection.
     fn get_collection_manager(self: @ContractState) -> ContractAddress;
-
-    /// Returns a list of all token IDs owned by the specified `user`.
-    ///
-    /// # Arguments
-    /// * `user` - The address whose tokens are being queried.
-    /// # Returns
-    /// * `Span<u256>` - A span containing all token IDs owned by the user.
-    fn get_all_user_tokens(self: @ContractState, user: ContractAddress) -> Span<u256>;
-
-    /// Returns the total number of tokens minted in this collection.
-    ///
-    /// # Returns
-    /// * `u256` - The total supply of tokens.
-    fn get_total_supply(self: @ContractState) -> u256;
-
-    /// Returns the URI metadata associated with the specified `token_id`.
-    ///
-    /// # Arguments
-    /// * `token_id` - The unique identifier for the token.
-    /// # Returns
-    /// * `ByteArray` - The URI of the token's metadata.
-    fn get_token_uri(self: @ContractState, token_id: u256) -> ByteArray;
-
-    /// Returns the owner address of the specified `token_id`.
-    ///
-    /// # Arguments
-    /// * `token_id` - The unique identifier for the token.
-    /// # Returns
-    /// * `ContractAddress` - The address of the token owner.
-    fn get_token_owner(self: @ContractState, token_id: u256) -> ContractAddress;
-
-    /// Checks if a given spender is approved to manage a specific token.
-    ///
-    /// # Arguments
-    /// - `self`: The contract state.
-    /// - `token_id`: The unique identifier of the token (u256).
-    /// - `spender`: The address of the spender to check approval for.
-    ///
-    /// # Returns
-    /// - `bool`: Returns `true` if the spender is approved for the specified token, otherwise
-    /// `false`.
-    fn is_approved_for_token(
-        self: @ContractState, token_id: u256, spender: ContractAddress,
-    ) -> bool;
 }

--- a/contracts/MIP-Collections-ERC721/src/types.cairo
+++ b/contracts/MIP-Collections-ERC721/src/types.cairo
@@ -43,7 +43,7 @@ pub impl TokenImpl of TokenTrait {
             } else {
                 col_bytes.append_byte(byte);
             }
-        };
+        }
 
         // Convert byte arrays to u256
         let collection_id = bytearray_to_u256(col_bytes);
@@ -114,7 +114,7 @@ fn bytearray_to_u256(bytes: ByteArray) -> u256 {
         let byte = bytes.at(i).unwrap();
         let digit = byte - 48; // '0' = 48 in ASCII
         result = result * 10_u256 + digit.try_into().unwrap();
-    };
+    }
     result
 }
 


### PR DESCRIPTION
Closes #123

Refactors the contract to support **SRC5** and prunes unnecessary code for a more streamlined interface.
Also introduces a new function to update the **IP NFT Class Hash**, allowing upgrades when:

* There are breaking changes in how NFTs are handled on Starknet, or
* We want to introduce new features to the NFT contracts without redeploying the entire contract.
