### PR TITLE
feat: impl base ipfs

### DIFF
--- a/contracts/MIP-Collections-ERC721/Scarb.lock
+++ b/contracts/MIP-Collections-ERC721/Scarb.lock
@@ -117,15 +117,15 @@ source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.20.0#77
 
 [[package]]
 name = "snforge_scarb_plugin"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:8630dcf3fa4df36a3d45e6a2d053cf84c548ab154e829fece99373ae5852921c"
+checksum = "sha256:2dd27e8215eea8785b3930e9f452e11b429ca262b1c1fbb071bfc173b9ebc125"
 
 [[package]]
 name = "snforge_std"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:981139c83359089540652c44f4a1a888c77409eedaa148377927cc63a604b67b"
+checksum = "sha256:89f759fa685d48ed0ba7152d2ac2eb168da08dfa8b84b2bee96e203dc5b2413e"
 dependencies = [
  "snforge_scarb_plugin",
 ]

--- a/contracts/MIP-Collections-ERC721/src/IPCollection.cairo
+++ b/contracts/MIP-Collections-ERC721/src/IPCollection.cairo
@@ -197,10 +197,11 @@ pub mod IPCollection {
             )
                 .unwrap();
 
+            let base: ByteArray = "https://ipfs.io/ipfs/";
             let collection = Collection {
                 name: name.clone(),
                 symbol: symbol.clone(),
-                base_uri: base_uri.clone(),
+                base_uri: format!("{}{}", base, base_uri.clone()),
                 owner: caller,
                 ip_nft: ip_nft_adddress,
                 is_active: true,
@@ -255,7 +256,7 @@ pub mod IPCollection {
             collection_stats.total_minted = next_token_id + 1;
             collection_stats.last_mint_time = get_block_timestamp();
 
-            let token_uri = IERC721Dispatcher { contract_address: collection.ip_nft }
+            let metadata_uri = IERC721Dispatcher { contract_address: collection.ip_nft }
                 .token_uri(next_token_id);
 
             self.collection_stats.entry(collection_id).write(collection_stats);
@@ -266,7 +267,7 @@ pub mod IPCollection {
                         collection_id,
                         token_id: next_token_id,
                         owner: recipient,
-                        metadata_uri: token_uri,
+                        metadata_uri: metadata_uri,
                     },
                 );
 

--- a/contracts/MIP-Collections-ERC721/src/IPNft.cairo
+++ b/contracts/MIP-Collections-ERC721/src/IPNft.cairo
@@ -136,7 +136,9 @@ pub mod IPNft {
 
         fn token_uri(self: @ContractState, token_id: u256) -> ByteArray {
             self.erc721._require_owned(token_id);
-            self.uris.read(token_id)
+            let base: ByteArray = "https://ipfs.io/ipfs/";
+            let uri = self.uris.read(token_id);
+            format!("{}{}", base, uri)
         }
     }
 
@@ -144,7 +146,9 @@ pub mod IPNft {
     impl ERC721MetadataCamelOnly of IERC721MetadataCamelOnly<ContractState> {
         fn tokenURI(self: @ContractState, tokenId: u256) -> ByteArray {
             self.erc721._require_owned(tokenId);
-            self.uris.read(tokenId)
+            let base: ByteArray = "https://ipfs.io/ipfs/";
+            let uri = self.uris.read(tokenId);
+            format!("{}{}", base, uri)
         }
     }
 
@@ -198,7 +202,9 @@ pub mod IPNft {
         /// # Returns
         /// * `ByteArray` - The base uri of the collection.
         fn base_uri(self: @ContractState) -> ByteArray {
-            self.erc721._base_uri()
+            let base: ByteArray = "https://ipfs.io/ipfs/";
+            let uri = self.erc721._base_uri();
+            format!("{}{}", base, uri)
         }
     }
 }


### PR DESCRIPTION
closes #129 

Introduce ipfs base `https://ipfs.io/ipfs/` so minting and collection creating only require passing in the IPFS CID.
 