### PR TITLE
feat(IP-Programmable-ERC1155): sequential on-chain token ids (v0.3.0)

### DIFF
--- a/contracts/IP-Programmable-ERC1155-Collections/Scarb.lock
+++ b/contracts/IP-Programmable-ERC1155-Collections/Scarb.lock
@@ -3,7 +3,7 @@ version = 1
 
 [[package]]
 name = "ip_programmable_erc1155_collections"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "openzeppelin",
  "snforge_std",

--- a/contracts/IP-Programmable-ERC1155-Collections/Scarb.toml
+++ b/contracts/IP-Programmable-ERC1155-Collections/Scarb.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ip_programmable_erc1155_collections"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024_07"
 
 [dependencies]

--- a/contracts/IP-Programmable-ERC1155-Collections/src/IPCollection.cairo
+++ b/contracts/IP-Programmable-ERC1155-Collections/src/IPCollection.cairo
@@ -88,6 +88,8 @@ pub mod IPCollection {
         token_creators: Map<u256, ContractAddress>,
         /// Block timestamp at first mint — immutable proof of creation date.
         token_registered_at: Map<u256, u64>,
+        /// Next edition id to assign. Initialized to 1 at deploy; incremented per mint_edition.
+        next_token_id: u256,
     }
 
     #[event]
@@ -147,6 +149,8 @@ pub mod IPCollection {
         // Initialize ERC-2981 with 0% royalty pointing to owner.
         // Owner can activate royalties post-deploy via set_default_royalty(receiver, fee_numerator).
         self.erc2981.initializer(owner, 0);
+        // Editions are numbered from 1.
+        self.next_token_id.write(1);
     }
 
     // --- ERC1155 URI override ---
@@ -189,6 +193,20 @@ pub mod IPCollection {
         }
 
         // ── Minting ────────────────────────────────────────────────────────────
+
+        fn mint_edition(
+            ref self: ContractState,
+            to: ContractAddress,
+            value: u256,
+            token_uri: ByteArray,
+        ) -> u256 {
+            self.ownable.assert_only_owner();
+            assert(!to.is_zero(), 'Recipient is zero address');
+            let token_id = self.next_token_id.read();
+            self._mint_new(get_caller_address(), to, token_id, value, token_uri);
+            self.next_token_id.write(token_id + 1);
+            token_id
+        }
 
         fn mint_item(
             ref self: ContractState,
@@ -264,6 +282,35 @@ pub mod IPCollection {
 
     #[generate_trait]
     impl InternalImpl of InternalTrait {
+        /// Mints a brand-new edition: always records provenance (the id is guaranteed fresh
+        /// by the counter). `value` must be > 0; `token_uri` length is validated.
+        fn _mint_new(
+            ref self: ContractState,
+            creator: ContractAddress,
+            to: ContractAddress,
+            token_id: u256,
+            value: u256,
+            token_uri: ByteArray,
+        ) {
+            assert(value > 0, 'Value must be > 0');
+            assert(
+                token_uri.len() > 0 && token_uri.len() <= MAX_TOKEN_URI_LEN,
+                'Invalid URI length',
+            );
+            let timestamp = get_block_timestamp();
+            self.token_uris.write(token_id, token_uri.clone());
+            self.token_creators.write(token_id, creator);
+            self.token_registered_at.write(token_id, timestamp);
+            self.erc1155.mint_with_acceptance_check(to, token_id, value, array![].span());
+            self
+                .emit(
+                    IPMinted {
+                        token_id, recipient: to, value, uri: token_uri,
+                        creator, registered_at: timestamp,
+                    },
+                );
+        }
+
         /// Mints a single token type, recording immutable IP provenance on first mint.
         ///
         /// `creator` is the caller (collection owner) — the IP author under the Berne Convention.

--- a/contracts/IP-Programmable-ERC1155-Collections/src/IPCollection.cairo
+++ b/contracts/IP-Programmable-ERC1155-Collections/src/IPCollection.cairo
@@ -17,20 +17,19 @@
 
 #[starknet::contract]
 pub mod IPCollection {
-    use openzeppelin::introspection::src5::SRC5Component;
-    use openzeppelin::access::ownable::OwnableComponent;
-    use openzeppelin::token::erc1155::ERC1155Component;
-    use openzeppelin::token::erc1155::ERC1155HooksEmptyImpl;
-    use openzeppelin::token::erc1155::interface::IERC1155MetadataURI;
-    use openzeppelin::token::common::erc2981::{ERC2981Component, DefaultConfig};
-    use starknet::storage::{
-        Map, StoragePointerReadAccess, StoragePointerWriteAccess, StorageMapReadAccess,
-        StorageMapWriteAccess,
-    };
     use core::num::traits::Zero;
+    use openzeppelin::access::ownable::OwnableComponent;
+    use openzeppelin::introspection::src5::SRC5Component;
+    use openzeppelin::token::common::erc2981::{DefaultConfig, ERC2981Component};
+    use openzeppelin::token::erc1155::interface::IERC1155MetadataURI;
+    use openzeppelin::token::erc1155::{ERC1155Component, ERC1155HooksEmptyImpl};
+    use starknet::storage::{
+        Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
+        StoragePointerWriteAccess,
+    };
     use starknet::{ContractAddress, get_block_timestamp, get_caller_address};
     use crate::interfaces::IIPCollection::IIPCollection;
-    use crate::types::{TokenData, MAX_TOKEN_URI_LEN};
+    use crate::types::{MAX_TOKEN_URI_LEN, TokenData};
 
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
@@ -59,7 +58,8 @@ pub mod IPCollection {
     #[abi(embed_v0)]
     impl ERC2981InfoImpl = ERC2981Component::ERC2981InfoImpl<ContractState>;
     #[abi(embed_v0)]
-    impl ERC2981AdminOwnableImpl = ERC2981Component::ERC2981AdminOwnableImpl<ContractState>;
+    impl ERC2981AdminOwnableImpl =
+        ERC2981Component::ERC2981AdminOwnableImpl<ContractState>;
     impl ERC2981InternalImpl = ERC2981Component::InternalImpl<ContractState>;
 
     #[storage]
@@ -147,7 +147,8 @@ pub mod IPCollection {
         self.collection_base_uri.write(base_uri);
         self.collection_creator.write(owner);
         // Initialize ERC-2981 with 0% royalty pointing to owner.
-        // Owner can activate royalties post-deploy via set_default_royalty(receiver, fee_numerator).
+        // Owner can activate royalties post-deploy via set_default_royalty(receiver,
+        // fee_numerator).
         self.erc2981.initializer(owner, 0);
         // Editions are numbered from 1.
         self.next_token_id.write(1);
@@ -174,7 +175,8 @@ pub mod IPCollection {
 
     #[abi(embed_v0)]
     impl IPCollectionImpl of IIPCollection<ContractState> {
-        // ── Collection metadata ────────────────────────────────────────────────
+        // ── Collection metadata
+        // ────────────────────────────────────────────────
 
         fn name(self: @ContractState) -> ByteArray {
             self.collection_name.read()
@@ -189,16 +191,14 @@ pub mod IPCollection {
         }
 
         fn version(self: @ContractState) -> ByteArray {
-            "0.2.0"
+            "0.3.0"
         }
 
-        // ── Minting ────────────────────────────────────────────────────────────
+        // ── Minting
+        // ────────────────────────────────────────────────────────────
 
         fn mint_edition(
-            ref self: ContractState,
-            to: ContractAddress,
-            value: u256,
-            token_uri: ByteArray,
+            ref self: ContractState, to: ContractAddress, value: u256, token_uri: ByteArray,
         ) -> u256 {
             self.ownable.assert_only_owner();
             assert(!to.is_zero(), 'Recipient is zero address');
@@ -229,9 +229,7 @@ pub mod IPCollection {
             ids.span()
         }
 
-        fn add_supply(
-            ref self: ContractState, to: ContractAddress, token_id: u256, value: u256,
-        ) {
+        fn add_supply(ref self: ContractState, to: ContractAddress, token_id: u256, value: u256) {
             self.ownable.assert_only_owner();
             assert(!to.is_zero(), 'Recipient is zero address');
             assert(value > 0, 'Value must be > 0');
@@ -241,7 +239,9 @@ pub mod IPCollection {
             self
                 .emit(
                     IPMinted {
-                        token_id, recipient: to, value,
+                        token_id,
+                        recipient: to,
+                        value,
                         uri: self.token_uris.read(token_id),
                         creator,
                         registered_at: self.token_registered_at.read(token_id),
@@ -249,7 +249,8 @@ pub mod IPCollection {
                 );
         }
 
-        // ── Provenance queries ─────────────────────────────────────────────────
+        // ── Provenance queries
+        // ─────────────────────────────────────────────────
 
         fn get_collection_creator(self: @ContractState) -> ContractAddress {
             self.collection_creator.read()
@@ -303,8 +304,7 @@ pub mod IPCollection {
         ) {
             assert(value > 0, 'Value must be > 0');
             assert(
-                token_uri.len() > 0 && token_uri.len() <= MAX_TOKEN_URI_LEN,
-                'Invalid URI length',
+                token_uri.len() > 0 && token_uri.len() <= MAX_TOKEN_URI_LEN, 'Invalid URI length',
             );
             let timestamp = get_block_timestamp();
             self.token_uris.write(token_id, token_uri.clone());
@@ -314,11 +314,14 @@ pub mod IPCollection {
             self
                 .emit(
                     IPMinted {
-                        token_id, recipient: to, value, uri: token_uri,
-                        creator, registered_at: timestamp,
+                        token_id,
+                        recipient: to,
+                        value,
+                        uri: token_uri,
+                        creator,
+                        registered_at: timestamp,
                     },
                 );
         }
-
     }
 }

--- a/contracts/IP-Programmable-ERC1155-Collections/src/IPCollection.cairo
+++ b/contracts/IP-Programmable-ERC1155-Collections/src/IPCollection.cairo
@@ -256,6 +256,14 @@ pub mod IPCollection {
                 registered_at: self.token_registered_at.read(token_id),
             }
         }
+
+        fn total_editions(self: @ContractState) -> u256 {
+            self.next_token_id.read() - 1
+        }
+
+        fn token_exists(self: @ContractState, token_id: u256) -> bool {
+            self.token_creators.read(token_id).is_non_zero()
+        }
     }
 
     // --- Internal helpers ---

--- a/contracts/IP-Programmable-ERC1155-Collections/src/IPCollection.cairo
+++ b/contracts/IP-Programmable-ERC1155-Collections/src/IPCollection.cairo
@@ -106,7 +106,7 @@ pub mod IPCollection {
         IPMinted: IPMinted,
     }
 
-    /// Emitted on every mint_item call (single or via batch_mint_item).
+    /// Emitted on every mint (mint_edition, batch_mint_edition, add_supply).
     /// `token_id` and `recipient` are indexed for efficient indexer filtering.
     #[derive(Drop, starknet::Event)]
     pub struct IPMinted {
@@ -208,44 +208,24 @@ pub mod IPCollection {
             token_id
         }
 
-        fn mint_item(
-            ref self: ContractState,
-            to: ContractAddress,
-            token_id: u256,
-            value: u256,
-            token_uri: ByteArray,
+        fn add_supply(
+            ref self: ContractState, to: ContractAddress, token_id: u256, value: u256,
         ) {
             self.ownable.assert_only_owner();
             assert(!to.is_zero(), 'Recipient is zero address');
             assert(value > 0, 'Value must be > 0');
-
-            let creator = get_caller_address();
-            self._mint_single(creator, to, token_id, value, token_uri);
-        }
-
-        fn batch_mint_item(
-            ref self: ContractState,
-            to: ContractAddress,
-            token_ids: Span<u256>,
-            values: Span<u256>,
-            token_uris: Array<ByteArray>,
-        ) {
-            self.ownable.assert_only_owner();
-            assert(!to.is_zero(), 'Recipient is zero address');
-            assert(token_ids.len() == values.len(), 'Array length mismatch');
-            assert(token_ids.len() == token_uris.len(), 'Array length mismatch');
-
-            let creator = get_caller_address();
-            for i in 0..token_ids.len() {
-                self
-                    ._mint_single(
+            let creator = self.token_creators.read(token_id);
+            assert(creator.is_non_zero(), 'Token does not exist');
+            self.erc1155.mint_with_acceptance_check(to, token_id, value, array![].span());
+            self
+                .emit(
+                    IPMinted {
+                        token_id, recipient: to, value,
+                        uri: self.token_uris.read(token_id),
                         creator,
-                        to,
-                        *token_ids.at(i),
-                        *values.at(i),
-                        token_uris.at(i).clone(),
-                    );
-            }
+                        registered_at: self.token_registered_at.read(token_id),
+                    },
+                );
         }
 
         // ── Provenance queries ─────────────────────────────────────────────────
@@ -307,63 +287,6 @@ pub mod IPCollection {
                     IPMinted {
                         token_id, recipient: to, value, uri: token_uri,
                         creator, registered_at: timestamp,
-                    },
-                );
-        }
-
-        /// Mints a single token type, recording immutable IP provenance on first mint.
-        ///
-        /// `creator` is the caller (collection owner) — the IP author under the Berne Convention.
-        /// `to` is the recipient who receives the minted supply (may differ from creator).
-        /// `value` must be > 0.
-        fn _mint_single(
-            ref self: ContractState,
-            creator: ContractAddress,
-            to: ContractAddress,
-            token_id: u256,
-            value: u256,
-            token_uri: ByteArray,
-        ) {
-            assert(value > 0, 'Value must be > 0');
-
-            let is_new = self.token_creators.read(token_id).is_zero();
-            let timestamp = get_block_timestamp();
-
-            if is_new {
-                // Keep URI storage protocol-neutral so future metadata systems work without
-                // redeploying the collection implementation.
-                assert(
-                    token_uri.len() > 0 && token_uri.len() <= MAX_TOKEN_URI_LEN,
-                    'Invalid URI length',
-                );
-
-                self.token_uris.write(token_id, token_uri.clone());
-                self.token_creators.write(token_id, creator);
-                self.token_registered_at.write(token_id, timestamp);
-            }
-
-            self.erc1155.mint_with_acceptance_check(to, token_id, value, array![].span());
-
-            // Use local vars on first mint to avoid reading back what we just wrote.
-            let (event_creator, registered_at, uri) = if is_new {
-                (creator, timestamp, token_uri)
-            } else {
-                (
-                    self.token_creators.read(token_id),
-                    self.token_registered_at.read(token_id),
-                    self.token_uris.read(token_id),
-                )
-            };
-
-            self
-                .emit(
-                    IPMinted {
-                        token_id,
-                        recipient: to,
-                        value,
-                        uri,
-                        creator: event_creator,
-                        registered_at,
                     },
                 );
         }

--- a/contracts/IP-Programmable-ERC1155-Collections/src/IPCollection.cairo
+++ b/contracts/IP-Programmable-ERC1155-Collections/src/IPCollection.cairo
@@ -208,6 +208,27 @@ pub mod IPCollection {
             token_id
         }
 
+        fn batch_mint_edition(
+            ref self: ContractState,
+            to: ContractAddress,
+            values: Span<u256>,
+            token_uris: Array<ByteArray>,
+        ) -> Span<u256> {
+            self.ownable.assert_only_owner();
+            assert(!to.is_zero(), 'Recipient is zero address');
+            assert(values.len() == token_uris.len(), 'Array length mismatch');
+            let creator = get_caller_address();
+            let mut ids: Array<u256> = array![];
+            let mut id = self.next_token_id.read();
+            for i in 0..values.len() {
+                self._mint_new(creator, to, id, *values.at(i), token_uris.at(i).clone());
+                ids.append(id);
+                id = id + 1;
+            }
+            self.next_token_id.write(id);
+            ids.span()
+        }
+
         fn add_supply(
             ref self: ContractState, to: ContractAddress, token_id: u256, value: u256,
         ) {

--- a/contracts/IP-Programmable-ERC1155-Collections/src/IPCollectionFactory.cairo
+++ b/contracts/IP-Programmable-ERC1155-Collections/src/IPCollectionFactory.cairo
@@ -1,31 +1,20 @@
 // DESIGN: IPCollectionFactory is the single deploy point for all IPCollection contracts.
 // Anyone can deploy a new collection — the caller becomes its owner and IP creator.
-// The factory owner can update the class hash for future deployments without affecting
-// already-deployed collections (which are immutable standalone contracts).
+// The factory is fully immutable and ownerless: the collection class hash is fixed at
+// deploy time. Protocol evolution = deploy a new factory, never mutate this one.
 
 #[starknet::contract]
 pub mod IPCollectionFactory {
-    use openzeppelin::access::ownable::OwnableComponent;
+    use core::hash::{HashStateExTrait, HashStateTrait};
+    use core::poseidon::PoseidonTrait;
     use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
     use starknet::syscalls::deploy_syscall;
-    use starknet::{ClassHash, ContractAddress, get_caller_address, SyscallResultTrait};
-    use core::num::traits::Zero;
-    use core::poseidon::PoseidonTrait;
-    use core::hash::{HashStateTrait, HashStateExTrait};
+    use starknet::{ClassHash, ContractAddress, SyscallResultTrait, get_caller_address};
     use crate::interfaces::IIPCollectionFactory::IIPCollectionFactory;
-
-    component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
-
-    #[abi(embed_v0)]
-    impl OwnableMixinImpl = OwnableComponent::OwnableMixinImpl<ContractState>;
-    impl OwnableInternalImpl = OwnableComponent::InternalImpl<ContractState>;
 
     #[storage]
     struct Storage {
-        #[substorage(v0)]
-        ownable: OwnableComponent::Storage,
-        /// Class hash used to deploy new IPCollection instances.
-        /// Updatable by factory owner for protocol upgrades; existing collections unaffected.
+        /// Class hash used to deploy new IPCollection instances. Immutable — fixed at deploy.
         ip_collection_class_hash: ClassHash,
         /// Monotonically incrementing nonce for unique deploy salts.
         deploy_nonce: felt252,
@@ -34,10 +23,7 @@ pub mod IPCollectionFactory {
     #[event]
     #[derive(Drop, starknet::Event)]
     pub enum Event {
-        #[flat]
-        OwnableEvent: OwnableComponent::Event,
         CollectionDeployed: CollectionDeployed,
-        CollectionClassHashUpdated: CollectionClassHashUpdated,
     }
 
     /// Emitted each time a new IPCollection is deployed via `deploy_collection`.
@@ -52,27 +38,14 @@ pub mod IPCollectionFactory {
         pub base_uri: ByteArray,
     }
 
-    /// Emitted when the factory owner updates the class hash used for future deployments.
-    #[derive(Drop, starknet::Event)]
-    pub struct CollectionClassHashUpdated {
-        pub previous_class_hash: ClassHash,
-        pub new_class_hash: ClassHash,
-    }
-
     /// Deploys a new IPCollectionFactory.
     ///
     /// # Arguments
-    /// * `owner`                 - Address that owns the factory (can update class hash)
-    /// * `collection_class_hash` - Class hash of the IPCollection contract to deploy
+    /// * `collection_class_hash` - Class hash of the IPCollection contract to deploy.
+    ///   Fixed forever; the factory is ownerless and immutable.
     #[constructor]
-    fn constructor(
-        ref self: ContractState,
-        owner: ContractAddress,
-        collection_class_hash: ClassHash,
-    ) {
-        assert(!owner.is_zero(), 'Owner is zero address');
+    fn constructor(ref self: ContractState, collection_class_hash: ClassHash) {
         assert(collection_class_hash.into() != 0_felt252, 'Class hash is zero');
-        self.ownable.initializer(owner);
         self.ip_collection_class_hash.write(collection_class_hash);
         // deploy_nonce defaults to 0 — no explicit write needed
     }
@@ -84,29 +57,11 @@ pub mod IPCollectionFactory {
         }
 
         fn version(self: @ContractState) -> ByteArray {
-            "0.2.0"
-        }
-
-        fn update_collection_class_hash(ref self: ContractState, new_class_hash: ClassHash) {
-            self.ownable.assert_only_owner();
-            assert(new_class_hash.into() != 0_felt252, 'Class hash is zero');
-
-            let previous_class_hash = self.ip_collection_class_hash.read();
-            self.ip_collection_class_hash.write(new_class_hash);
-            self
-                .emit(
-                    CollectionClassHashUpdated {
-                        previous_class_hash,
-                        new_class_hash,
-                    },
-                );
+            "0.3.0"
         }
 
         fn deploy_collection(
-            ref self: ContractState,
-            name: ByteArray,
-            symbol: ByteArray,
-            base_uri: ByteArray,
+            ref self: ContractState, name: ByteArray, symbol: ByteArray, base_uri: ByteArray,
         ) -> ContractAddress {
             assert(name.len() > 0, 'Name must not be empty');
             assert(symbol.len() > 0, 'Symbol must not be empty');

--- a/contracts/IP-Programmable-ERC1155-Collections/src/interfaces/IIPCollection.cairo
+++ b/contracts/IP-Programmable-ERC1155-Collections/src/interfaces/IIPCollection.cairo
@@ -60,4 +60,10 @@ pub trait IIPCollection<TContractState> {
     /// Returns all provenance fields for a token type in a single call.
     /// Reverts if the token type has never been minted.
     fn get_token_data(self: @TContractState, token_id: u256) -> TokenData;
+
+    /// Number of distinct editions minted so far (sequential ids 1..=total_editions).
+    fn total_editions(self: @TContractState) -> u256;
+
+    /// True if `token_id` has been minted (an edition exists).
+    fn token_exists(self: @TContractState, token_id: u256) -> bool;
 }

--- a/contracts/IP-Programmable-ERC1155-Collections/src/interfaces/IIPCollection.cairo
+++ b/contracts/IP-Programmable-ERC1155-Collections/src/interfaces/IIPCollection.cairo
@@ -9,7 +9,8 @@ use crate::types::TokenData;
 /// at first mint of each token type, satisfying the Berne Convention authorship standard.
 #[starknet::interface]
 pub trait IIPCollection<TContractState> {
-    // ── Collection metadata ────────────────────────────────────────────────────
+    // ── Collection metadata
+    // ────────────────────────────────────────────────────
 
     /// Human-readable collection name set at deploy time.
     fn name(self: @TContractState) -> ByteArray;
@@ -25,17 +26,15 @@ pub trait IIPCollection<TContractState> {
     /// Returns the immutable implementation version for this deployed collection class.
     fn version(self: @TContractState) -> ByteArray;
 
-    // ── Minting ────────────────────────────────────────────────────────────────
+    // ── Minting
+    // ────────────────────────────────────────────────────────────────
 
     /// Mints a NEW edition with an id assigned atomically on-chain (sequential from 1).
     /// Owner only. `to` must not be zero; `value` must be > 0; `token_uri` must be valid length.
     /// Records the caller as the immutable IP creator + registration timestamp.
     /// Returns the assigned token id.
     fn mint_edition(
-        ref self: TContractState,
-        to: ContractAddress,
-        value: u256,
-        token_uri: ByteArray,
+        ref self: TContractState, to: ContractAddress, value: u256, token_uri: ByteArray,
     ) -> u256;
 
     /// Mints N new editions in one call; ids are assigned sequentially. Owner only.
@@ -51,7 +50,8 @@ pub trait IIPCollection<TContractState> {
     /// Owner only. Reverts if `token_id` has never been minted. URI/provenance unchanged.
     fn add_supply(ref self: TContractState, to: ContractAddress, token_id: u256, value: u256);
 
-    // ── Provenance queries ─────────────────────────────────────────────────────
+    // ── Provenance queries
+    // ─────────────────────────────────────────────────────
 
     /// Returns the address that deployed this collection via the factory.
     /// Immutable — does not change if ownership is transferred.

--- a/contracts/IP-Programmable-ERC1155-Collections/src/interfaces/IIPCollection.cairo
+++ b/contracts/IP-Programmable-ERC1155-Collections/src/interfaces/IIPCollection.cairo
@@ -38,35 +38,9 @@ pub trait IIPCollection<TContractState> {
         token_uri: ByteArray,
     ) -> u256;
 
-    /// Mints `value` copies of a new or existing token type to `to`.
-    ///
-    /// Owner only. `to` must not be the zero address. `value` must be > 0.
-    /// For new token types (first mint of this `token_id`):
-    ///   - `token_uri` is stored permanently and must have a valid length.
-    ///   - The caller (owner) is recorded as the original IP creator.
-    ///   - Block timestamp is recorded as the registration date.
-    /// For existing token types (subsequent mints): `token_uri` is ignored.
-    fn mint_item(
-        ref self: TContractState,
-        to: ContractAddress,
-        token_id: u256,
-        value: u256,
-        token_uri: ByteArray,
-    );
-
-    /// Batch version of `mint_item`. All token IDs in the batch are minted to `to`.
-    ///
-    /// Owner only. `to` must not be the zero address.
-    /// `token_ids`, `values`, and `token_uris` must have equal length.
-    /// All `value` entries must be > 0.
-    /// For each token_id: URI is stored only on first mint of that type.
-    fn batch_mint_item(
-        ref self: TContractState,
-        to: ContractAddress,
-        token_ids: Span<u256>,
-        values: Span<u256>,
-        token_uris: Array<ByteArray>,
-    );
+    /// Mints `value` additional copies of an EXISTING edition to `to`.
+    /// Owner only. Reverts if `token_id` has never been minted. URI/provenance unchanged.
+    fn add_supply(ref self: TContractState, to: ContractAddress, token_id: u256, value: u256);
 
     // ── Provenance queries ─────────────────────────────────────────────────────
 

--- a/contracts/IP-Programmable-ERC1155-Collections/src/interfaces/IIPCollection.cairo
+++ b/contracts/IP-Programmable-ERC1155-Collections/src/interfaces/IIPCollection.cairo
@@ -27,6 +27,17 @@ pub trait IIPCollection<TContractState> {
 
     // ── Minting ────────────────────────────────────────────────────────────────
 
+    /// Mints a NEW edition with an id assigned atomically on-chain (sequential from 1).
+    /// Owner only. `to` must not be zero; `value` must be > 0; `token_uri` must be valid length.
+    /// Records the caller as the immutable IP creator + registration timestamp.
+    /// Returns the assigned token id.
+    fn mint_edition(
+        ref self: TContractState,
+        to: ContractAddress,
+        value: u256,
+        token_uri: ByteArray,
+    ) -> u256;
+
     /// Mints `value` copies of a new or existing token type to `to`.
     ///
     /// Owner only. `to` must not be the zero address. `value` must be > 0.

--- a/contracts/IP-Programmable-ERC1155-Collections/src/interfaces/IIPCollection.cairo
+++ b/contracts/IP-Programmable-ERC1155-Collections/src/interfaces/IIPCollection.cairo
@@ -38,6 +38,15 @@ pub trait IIPCollection<TContractState> {
         token_uri: ByteArray,
     ) -> u256;
 
+    /// Mints N new editions in one call; ids are assigned sequentially. Owner only.
+    /// `values` and `token_uris` must have equal length. Returns the assigned ids.
+    fn batch_mint_edition(
+        ref self: TContractState,
+        to: ContractAddress,
+        values: Span<u256>,
+        token_uris: Array<ByteArray>,
+    ) -> Span<u256>;
+
     /// Mints `value` additional copies of an EXISTING edition to `to`.
     /// Owner only. Reverts if `token_id` has never been minted. URI/provenance unchanged.
     fn add_supply(ref self: TContractState, to: ContractAddress, token_id: u256, value: u256);

--- a/contracts/IP-Programmable-ERC1155-Collections/src/interfaces/IIPCollectionFactory.cairo
+++ b/contracts/IP-Programmable-ERC1155-Collections/src/interfaces/IIPCollectionFactory.cairo
@@ -4,20 +4,15 @@ use starknet::{ClassHash, ContractAddress};
 ///
 /// The factory is the single deployment point for all IP ERC-1155 collections.
 /// Anyone can deploy a new collection — the caller becomes its owner.
-/// The factory owner can update the class hash used for future deployments
-/// (e.g. after a protocol upgrade), without affecting existing collections.
+/// The factory is fully immutable and ownerless: the collection class hash is fixed
+/// at deploy time. Protocol evolution = deploy a new factory, never mutate this one.
 #[starknet::interface]
 pub trait IIPCollectionFactory<TContractState> {
-    /// Returns the class hash used to deploy new collections.
+    /// Returns the class hash used to deploy new collections (immutable).
     fn collection_class_hash(self: @TContractState) -> ClassHash;
 
     /// Returns the immutable implementation version for this deployed factory class.
     fn version(self: @TContractState) -> ByteArray;
-
-    /// Updates the class hash for future collection deployments.
-    /// Factory owner only. Does not affect already-deployed collections.
-    /// Emits `CollectionClassHashUpdated`.
-    fn update_collection_class_hash(ref self: TContractState, new_class_hash: ClassHash);
 
     /// Deploys a new IPCollection instance.
     ///
@@ -28,9 +23,6 @@ pub trait IIPCollectionFactory<TContractState> {
     /// Returns the address of the newly deployed collection.
     /// Emits `CollectionDeployed`.
     fn deploy_collection(
-        ref self: TContractState,
-        name: ByteArray,
-        symbol: ByteArray,
-        base_uri: ByteArray,
+        ref self: TContractState, name: ByteArray, symbol: ByteArray, base_uri: ByteArray,
     ) -> ContractAddress;
 }

--- a/contracts/IP-Programmable-ERC1155-Collections/src/lib.cairo
+++ b/contracts/IP-Programmable-ERC1155-Collections/src/lib.cairo
@@ -14,6 +14,6 @@ pub mod mock_contracts {
 
 #[cfg(test)]
 mod tests {
-    mod IPCollectionTest;
     mod IPCollectionFactoryTest;
+    mod IPCollectionTest;
 }

--- a/contracts/IP-Programmable-ERC1155-Collections/src/mock_contracts/ERC1155Receiver.cairo
+++ b/contracts/IP-Programmable-ERC1155-Collections/src/mock_contracts/ERC1155Receiver.cairo
@@ -6,7 +6,9 @@ pub mod ERC1155Receiver {
     use openzeppelin::token::erc1155::ERC1155ReceiverComponent;
 
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
-    component!(path: ERC1155ReceiverComponent, storage: erc1155_receiver, event: ERC1155ReceiverEvent);
+    component!(
+        path: ERC1155ReceiverComponent, storage: erc1155_receiver, event: ERC1155ReceiverEvent,
+    );
 
     #[abi(embed_v0)]
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;

--- a/contracts/IP-Programmable-ERC1155-Collections/src/tests/IPCollectionFactoryTest.cairo
+++ b/contracts/IP-Programmable-ERC1155-Collections/src/tests/IPCollectionFactoryTest.cairo
@@ -1,11 +1,11 @@
-use ip_programmable_erc1155_collections::interfaces::IIPCollectionFactory::{
-    IIPCollectionFactoryDispatcher, IIPCollectionFactoryDispatcherTrait,
+use ip_programmable_erc1155_collections::IPCollectionFactory::IPCollectionFactory::{
+    CollectionDeployed, Event,
 };
 use ip_programmable_erc1155_collections::interfaces::IIPCollection::{
     IIPCollectionDispatcher, IIPCollectionDispatcherTrait,
 };
-use ip_programmable_erc1155_collections::IPCollectionFactory::IPCollectionFactory::{
-    CollectionClassHashUpdated, CollectionDeployed, Event,
+use ip_programmable_erc1155_collections::interfaces::IIPCollectionFactory::{
+    IIPCollectionFactoryDispatcher, IIPCollectionFactoryDispatcherTrait,
 };
 use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
 use openzeppelin::token::erc1155::interface::{IERC1155Dispatcher, IERC1155DispatcherTrait};
@@ -15,7 +15,8 @@ use snforge_std::{
 };
 use starknet::{ClassHash, ContractAddress};
 
-// ─── Constants ─────────────────────────────────────────────────────────────────
+// ─── Constants
+// ─────────────────────────────────────────────────────────────────
 
 fn FACTORY_OWNER() -> ContractAddress {
     0x100.try_into().unwrap()
@@ -46,23 +47,23 @@ fn ZERO_CLASS_HASH() -> ClassHash {
     0.try_into().unwrap()
 }
 
-// ─── Helpers ───────────────────────────────────────────────────────────────────
+// ─── Helpers
+// ───────────────────────────────────────────────────────────────────
 
 fn collection_class_hash() -> ClassHash {
     let declare_result = declare("IPCollection").unwrap();
     *declare_result.contract_class().class_hash
 }
 
-fn deploy_factory(owner: ContractAddress) -> (IIPCollectionFactoryDispatcher, ContractAddress) {
+fn deploy_factory() -> (IIPCollectionFactoryDispatcher, ContractAddress) {
     let class_hash = collection_class_hash();
-    deploy_factory_with_class_hash(owner, class_hash)
+    deploy_factory_with_class_hash(class_hash)
 }
 
 fn deploy_factory_with_class_hash(
-    owner: ContractAddress, class_hash: ClassHash,
+    class_hash: ClassHash,
 ) -> (IIPCollectionFactoryDispatcher, ContractAddress) {
     let mut calldata: Array<felt252> = array![];
-    owner.serialize(ref calldata);
     class_hash.serialize(ref calldata);
 
     let declare_result = declare("IPCollectionFactory").unwrap();
@@ -80,36 +81,27 @@ fn deploy_receiver() -> ContractAddress {
     address
 }
 
-// ─── Constructor ───────────────────────────────────────────────────────────────
-
-#[test]
-fn test_factory_constructor_owner() {
-    let owner = FACTORY_OWNER();
-    let (_, address) = deploy_factory(owner);
-    let ownable = IOwnableDispatcher { contract_address: address };
-    assert_eq!(ownable.owner(), owner);
-}
+// ─── Constructor
+// ───────────────────────────────────────────────────────────────
 
 #[test]
 fn test_factory_constructor_class_hash() {
-    let owner = FACTORY_OWNER();
-    let (factory, _) = deploy_factory(owner);
+    let (factory, _) = deploy_factory();
     assert_eq!(factory.collection_class_hash(), collection_class_hash());
 }
 
 #[test]
 fn test_factory_version() {
-    let owner = FACTORY_OWNER();
-    let (factory, _) = deploy_factory(owner);
-    assert_eq!(factory.version(), "0.2.0");
+    let (factory, _) = deploy_factory();
+    assert_eq!(factory.version(), "0.3.0");
 }
 
-// ─── deploy_collection ─────────────────────────────────────────────────────────
+// ─── deploy_collection
+// ─────────────────────────────────────────────────────────
 
 #[test]
 fn test_deploy_collection_returns_nonzero_address() {
-    let owner = FACTORY_OWNER();
-    let (factory, address) = deploy_factory(owner);
+    let (factory, address) = deploy_factory();
 
     cheat_caller_address(address, USER1(), CheatSpan::TargetCalls(1));
     let collection_address = factory
@@ -120,8 +112,7 @@ fn test_deploy_collection_returns_nonzero_address() {
 
 #[test]
 fn test_deploy_collection_caller_is_owner() {
-    let owner = FACTORY_OWNER();
-    let (factory, address) = deploy_factory(owner);
+    let (factory, address) = deploy_factory();
 
     cheat_caller_address(address, USER1(), CheatSpan::TargetCalls(1));
     let collection_address = factory
@@ -133,8 +124,7 @@ fn test_deploy_collection_caller_is_owner() {
 
 #[test]
 fn test_deploy_collection_creator_is_caller() {
-    let owner = FACTORY_OWNER();
-    let (factory, address) = deploy_factory(owner);
+    let (factory, address) = deploy_factory();
 
     cheat_caller_address(address, USER1(), CheatSpan::TargetCalls(1));
     let collection_address = factory
@@ -146,8 +136,7 @@ fn test_deploy_collection_creator_is_caller() {
 
 #[test]
 fn test_deploy_collection_stores_name_symbol_base_uri() {
-    let owner = FACTORY_OWNER();
-    let (factory, address) = deploy_factory(owner);
+    let (factory, address) = deploy_factory();
 
     cheat_caller_address(address, USER1(), CheatSpan::TargetCalls(1));
     let collection_address = factory
@@ -161,8 +150,7 @@ fn test_deploy_collection_stores_name_symbol_base_uri() {
 
 #[test]
 fn test_deploy_collection_empty_base_uri_allowed() {
-    let owner = FACTORY_OWNER();
-    let (factory, address) = deploy_factory(owner);
+    let (factory, address) = deploy_factory();
 
     cheat_caller_address(address, USER1(), CheatSpan::TargetCalls(1));
     let collection_address = factory.deploy_collection(COLLECTION_NAME(), COLLECTION_SYMBOL(), "");
@@ -173,8 +161,7 @@ fn test_deploy_collection_empty_base_uri_allowed() {
 
 #[test]
 fn test_deploy_collection_emits_collection_deployed_event() {
-    let owner = FACTORY_OWNER();
-    let (factory, address) = deploy_factory(owner);
+    let (factory, address) = deploy_factory();
 
     cheat_caller_address(address, USER1(), CheatSpan::TargetCalls(1));
     let mut spy = spy_events();
@@ -202,8 +189,7 @@ fn test_deploy_collection_emits_collection_deployed_event() {
 
 #[test]
 fn test_deploy_two_collections_different_addresses() {
-    let owner = FACTORY_OWNER();
-    let (factory, address) = deploy_factory(owner);
+    let (factory, address) = deploy_factory();
 
     cheat_caller_address(address, USER1(), CheatSpan::TargetCalls(1));
     let addr1 = factory
@@ -219,8 +205,7 @@ fn test_deploy_two_collections_different_addresses() {
 #[test]
 fn test_same_caller_same_name_produces_different_addresses() {
     // The nonce ensures uniqueness even when name, symbol, and caller are identical.
-    let owner = FACTORY_OWNER();
-    let (factory, address) = deploy_factory(owner);
+    let (factory, address) = deploy_factory();
 
     cheat_caller_address(address, USER1(), CheatSpan::TargetCalls(1));
     let addr1 = factory
@@ -235,8 +220,7 @@ fn test_same_caller_same_name_produces_different_addresses() {
 
 #[test]
 fn test_deploy_collection_by_different_callers() {
-    let owner = FACTORY_OWNER();
-    let (factory, address) = deploy_factory(owner);
+    let (factory, address) = deploy_factory();
 
     cheat_caller_address(address, USER1(), CheatSpan::TargetCalls(1));
     let addr1 = factory
@@ -254,8 +238,7 @@ fn test_deploy_collection_by_different_callers() {
 
 #[test]
 fn test_deployed_collection_can_mint() {
-    let owner = FACTORY_OWNER();
-    let (factory, address) = deploy_factory(owner);
+    let (factory, address) = deploy_factory();
 
     cheat_caller_address(address, USER1(), CheatSpan::TargetCalls(1));
     let collection_address = factory
@@ -273,13 +256,13 @@ fn test_deployed_collection_can_mint() {
     assert_eq!(erc1155.balance_of(recipient, 1), 10);
 }
 
-// ─── Input validation ──────────────────────────────────────────────────────────
+// ─── Input validation
+// ──────────────────────────────────────────────────────────
 
 #[test]
 #[should_panic(expected: 'Name must not be empty')]
 fn test_deploy_collection_empty_name_rejected() {
-    let owner = FACTORY_OWNER();
-    let (factory, address) = deploy_factory(owner);
+    let (factory, address) = deploy_factory();
 
     cheat_caller_address(address, USER1(), CheatSpan::TargetCalls(1));
     factory.deploy_collection("", COLLECTION_SYMBOL(), COLLECTION_BASE_URI());
@@ -288,81 +271,18 @@ fn test_deploy_collection_empty_name_rejected() {
 #[test]
 #[should_panic(expected: 'Symbol must not be empty')]
 fn test_deploy_collection_empty_symbol_rejected() {
-    let owner = FACTORY_OWNER();
-    let (factory, address) = deploy_factory(owner);
+    let (factory, address) = deploy_factory();
 
     cheat_caller_address(address, USER1(), CheatSpan::TargetCalls(1));
     factory.deploy_collection(COLLECTION_NAME(), "", COLLECTION_BASE_URI());
 }
 
-// ─── update_collection_class_hash ──────────────────────────────────────────────
-
-#[test]
-fn test_update_class_hash_by_owner() {
-    let owner = FACTORY_OWNER();
-    let (factory, address) = deploy_factory(owner);
-
-    let new_class_hash = collection_class_hash();
-    cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    factory.update_collection_class_hash(new_class_hash);
-
-    assert_eq!(factory.collection_class_hash(), new_class_hash);
-}
-
-#[test]
-fn test_update_class_hash_emits_event() {
-    let owner = FACTORY_OWNER();
-    let (factory, address) = deploy_factory(owner);
-
-    let previous_class_hash = factory.collection_class_hash();
-    let new_class_hash = collection_class_hash();
-
-    cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    let mut spy = spy_events();
-    factory.update_collection_class_hash(new_class_hash);
-
-    spy
-        .assert_emitted(
-            @array![
-                (
-                    address,
-                    Event::CollectionClassHashUpdated(
-                        CollectionClassHashUpdated {
-                            previous_class_hash,
-                            new_class_hash,
-                        },
-                    ),
-                ),
-            ],
-        );
-}
-
-#[test]
-#[should_panic(expected: 'Caller is not the owner')]
-fn test_update_class_hash_not_owner() {
-    let owner = FACTORY_OWNER();
-    let (factory, address) = deploy_factory(owner);
-
-    cheat_caller_address(address, USER1(), CheatSpan::TargetCalls(1));
-    factory.update_collection_class_hash(collection_class_hash());
-}
-
-#[test]
-#[should_panic(expected: 'Class hash is zero')]
-fn test_update_class_hash_zero_rejected() {
-    let owner = FACTORY_OWNER();
-    let (factory, address) = deploy_factory(owner);
-
-    cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    factory.update_collection_class_hash(ZERO_CLASS_HASH());
-}
-
-// ─── Anyone can deploy ─────────────────────────────────────────────────────────
+// ─── Anyone can deploy
+// ─────────────────────────────────────────────────────────
 
 #[test]
 fn test_any_address_can_deploy_collection() {
-    let owner = FACTORY_OWNER();
-    let (factory, address) = deploy_factory(owner);
+    let (factory, address) = deploy_factory();
 
     cheat_caller_address(address, USER1(), CheatSpan::TargetCalls(1));
     let addr1 = factory

--- a/contracts/IP-Programmable-ERC1155-Collections/src/tests/IPCollectionFactoryTest.cairo
+++ b/contracts/IP-Programmable-ERC1155-Collections/src/tests/IPCollectionFactoryTest.cairo
@@ -266,9 +266,10 @@ fn test_deployed_collection_can_mint() {
     let token_uri: ByteArray = "ipfs://QmDeployedCollectionToken";
 
     cheat_caller_address(collection_address, USER1(), CheatSpan::TargetCalls(1));
-    collection.mint_item(recipient, 1, 10, token_uri);
+    let token_id = collection.mint_edition(recipient, 10, token_uri);
 
     let erc1155 = IERC1155Dispatcher { contract_address: collection_address };
+    assert_eq!(token_id, 1);
     assert_eq!(erc1155.balance_of(recipient, 1), 10);
 }
 

--- a/contracts/IP-Programmable-ERC1155-Collections/src/tests/IPCollectionTest.cairo
+++ b/contracts/IP-Programmable-ERC1155-Collections/src/tests/IPCollectionTest.cairo
@@ -1,25 +1,25 @@
+use ip_programmable_erc1155_collections::IPCollection::IPCollection::{Event, IPMinted};
 use ip_programmable_erc1155_collections::interfaces::IIPCollection::{
     IIPCollectionDispatcher, IIPCollectionDispatcherTrait,
 };
-use ip_programmable_erc1155_collections::IPCollection::IPCollection::{Event, IPMinted};
+use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
+use openzeppelin::introspection::interface::{ISRC5Dispatcher, ISRC5DispatcherTrait};
+use openzeppelin::token::common::erc2981::interface::{
+    IERC2981AdminDispatcher, IERC2981AdminDispatcherTrait, IERC2981Dispatcher,
+    IERC2981DispatcherTrait, IERC2981InfoDispatcher, IERC2981InfoDispatcherTrait, IERC2981_ID,
+};
 use openzeppelin::token::erc1155::interface::{
     IERC1155Dispatcher, IERC1155DispatcherTrait, IERC1155MetadataURIDispatcher,
     IERC1155MetadataURIDispatcherTrait,
 };
-use openzeppelin::access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
-use openzeppelin::token::common::erc2981::interface::{
-    IERC2981Dispatcher, IERC2981DispatcherTrait, IERC2981AdminDispatcher,
-    IERC2981AdminDispatcherTrait, IERC2981InfoDispatcher, IERC2981InfoDispatcherTrait,
-};
-use openzeppelin::introspection::interface::{ISRC5Dispatcher, ISRC5DispatcherTrait};
-use openzeppelin::token::common::erc2981::interface::IERC2981_ID;
 use snforge_std::{
     CheatSpan, ContractClassTrait, DeclareResultTrait, EventSpyAssertionsTrait,
     cheat_block_timestamp, cheat_caller_address, declare, spy_events,
 };
 use starknet::ContractAddress;
 
-// ─── Constants ─────────────────────────────────────────────────────────────────
+// ─── Constants
+// ─────────────────────────────────────────────────────────────────
 
 fn OWNER() -> ContractAddress {
     0x100.try_into().unwrap()
@@ -56,7 +56,7 @@ fn LONG_URI() -> ByteArray {
     let mut uri: ByteArray = "";
     for _ in 0_u32..2049_u32 {
         uri.append_byte(97_u8);
-    };
+    }
     uri
 }
 fn BASE_URI() -> ByteArray {
@@ -70,7 +70,8 @@ const VALUE_1: u256 = 10;
 const VALUE_2: u256 = 5;
 const VALUE_3: u256 = 1;
 
-// ─── Helpers ───────────────────────────────────────────────────────────────────
+// ─── Helpers
+// ───────────────────────────────────────────────────────────────────
 
 /// Deploy a fresh ERC1155Receiver mock (used as minting recipient).
 fn deploy_receiver() -> ContractAddress {
@@ -101,7 +102,8 @@ fn deploy_collection(
     (dispatcher, address)
 }
 
-// ─── Constructor / metadata ────────────────────────────────────────────────────
+// ─── Constructor / metadata
+// ────────────────────────────────────────────────────
 
 #[test]
 fn test_constructor_owner() {
@@ -150,10 +152,11 @@ fn test_constructor_empty_base_uri() {
 fn test_contract_version() {
     let owner = OWNER();
     let (collection, _) = deploy_collection(owner, BASE_URI());
-    assert_eq!(collection.version(), "0.2.0");
+    assert_eq!(collection.version(), "0.3.0");
 }
 
-// ─── uri() fallback behaviour ──────────────────────────────────────────────────
+// ─── uri() fallback behaviour
+// ──────────────────────────────────────────────────
 
 #[test]
 fn test_uri_unminted_falls_back_to_base_uri() {
@@ -186,7 +189,8 @@ fn test_uri_minted_token_returns_per_token_uri() {
     assert_eq!(metadata.uri(TOKEN_ID_1), IPFS_URI());
 }
 
-// ─── mint_item ─────────────────────────────────────────────────────────────────
+// ─── mint_item
+// ─────────────────────────────────────────────────────────────────
 
 #[test]
 fn test_mint_item_ipfs_uri() {
@@ -413,7 +417,8 @@ fn test_total_editions_and_token_exists() {
     assert!(!collection.token_exists(3));
 }
 
-// ─── batch_mint_edition ──────────────────────────────────────────────────────────
+// ─── batch_mint_edition
+// ──────────────────────────────────────────────────────────
 
 #[test]
 fn test_batch_mint_edition_sequential() {
@@ -439,7 +444,10 @@ fn test_batch_then_single_continues_sequence() {
     let (collection, _) = deploy_collection(OWNER(), BASE_URI());
     let recipient = deploy_receiver();
     cheat_caller_address(collection.contract_address, OWNER(), CheatSpan::TargetCalls(2));
-    collection.batch_mint_edition(recipient, array![VALUE_1, VALUE_1].span(), array![IPFS_URI(), AR_URI()]);
+    collection
+        .batch_mint_edition(
+            recipient, array![VALUE_1, VALUE_1].span(), array![IPFS_URI(), AR_URI()],
+        );
     let next = collection.mint_edition(recipient, VALUE_1, HTTP_URI());
     assert_eq!(next, 3);
 }
@@ -470,7 +478,8 @@ fn test_batch_mint_edition_not_owner() {
     collection.batch_mint_edition(recipient, array![VALUE_1].span(), array![IPFS_URI()]);
 }
 
-// ─── add_supply (re-supply an existing edition) ──────────────────────────────────
+// ─── add_supply (re-supply an existing edition)
+// ──────────────────────────────────
 
 #[test]
 fn test_remint_existing_token_increases_balance() {
@@ -543,7 +552,8 @@ fn test_add_supply_non_owner_reverts() {
     collection.add_supply(recipient, id, VALUE_2);
 }
 
-// ─── Provenance query guards ───────────────────────────────────────────────────
+// ─── Provenance query guards
+// ───────────────────────────────────────────────────
 
 #[test]
 #[should_panic(expected: 'Token does not exist')]
@@ -569,7 +579,8 @@ fn test_get_token_data_nonexistent() {
     collection.get_token_data(TOKEN_ID_1);
 }
 
-// ─── ERC-1155 standard behaviour ──────────────────────────────────────────────
+// ─── ERC-1155 standard behaviour
+// ──────────────────────────────────────────────
 
 #[test]
 fn test_transfer_between_receivers() {
@@ -614,7 +625,8 @@ fn test_multiple_token_ids_independent_balances() {
     assert_eq!(erc1155.balance_of(recipient, TOKEN_ID_3), 0);
 }
 
-// ─── ERC-2981 royalty ──────────────────────────────────────────────────────────
+// ─── ERC-2981 royalty
+// ──────────────────────────────────────────────────────────
 
 #[test]
 fn test_royalty_default_is_zero_on_deploy() {
@@ -754,7 +766,8 @@ fn test_default_royalty_info_returns_denominator() {
     assert_eq!(denominator, 10_000);
 }
 
-// ─── mint_edition (on-chain sequential ids) ──────────────────────────────────────
+// ─── mint_edition (on-chain sequential ids)
+// ──────────────────────────────────────
 
 #[test]
 fn test_mint_edition_assigns_sequential_ids() {

--- a/contracts/IP-Programmable-ERC1155-Collections/src/tests/IPCollectionTest.cairo
+++ b/contracts/IP-Programmable-ERC1155-Collections/src/tests/IPCollectionTest.cairo
@@ -179,7 +179,7 @@ fn test_uri_minted_token_returns_per_token_uri() {
     let recipient = deploy_receiver();
 
     cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    collection.mint_item(recipient, TOKEN_ID_1, VALUE_1, IPFS_URI());
+    collection.mint_edition(recipient, VALUE_1, IPFS_URI());
 
     let metadata = IERC1155MetadataURIDispatcher { contract_address: address };
     // Minted token should return per-token URI, not base_uri
@@ -195,7 +195,7 @@ fn test_mint_item_ipfs_uri() {
     let recipient = deploy_receiver();
 
     cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    collection.mint_item(recipient, TOKEN_ID_1, VALUE_1, IPFS_URI());
+    collection.mint_edition(recipient, VALUE_1, IPFS_URI());
 
     let erc1155 = IERC1155Dispatcher { contract_address: address };
     assert_eq!(erc1155.balance_of(recipient, TOKEN_ID_1), VALUE_1);
@@ -208,7 +208,7 @@ fn test_mint_item_ar_uri() {
     let recipient = deploy_receiver();
 
     cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    collection.mint_item(recipient, TOKEN_ID_1, VALUE_1, AR_URI());
+    collection.mint_edition(recipient, VALUE_1, AR_URI());
 
     let erc1155 = IERC1155Dispatcher { contract_address: address };
     assert_eq!(erc1155.balance_of(recipient, TOKEN_ID_1), VALUE_1);
@@ -221,7 +221,7 @@ fn test_mint_item_future_uri_scheme() {
     let recipient = deploy_receiver();
 
     cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    collection.mint_item(recipient, TOKEN_ID_1, VALUE_1, FUTURE_URI());
+    collection.mint_edition(recipient, VALUE_1, FUTURE_URI());
 
     let metadata = IERC1155MetadataURIDispatcher { contract_address: address };
     assert_eq!(metadata.uri(TOKEN_ID_1), FUTURE_URI());
@@ -236,7 +236,7 @@ fn test_mint_item_creator_is_caller_not_recipient() {
     let recipient = deploy_receiver();
 
     cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    collection.mint_item(recipient, TOKEN_ID_1, VALUE_1, IPFS_URI());
+    collection.mint_edition(recipient, VALUE_1, IPFS_URI());
 
     assert_eq!(collection.get_token_creator(TOKEN_ID_1), owner);
 }
@@ -250,7 +250,7 @@ fn test_mint_item_stores_registered_at() {
     let mock_timestamp: u64 = 1700000000;
     cheat_block_timestamp(address, mock_timestamp, CheatSpan::TargetCalls(1));
     cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    collection.mint_item(recipient, TOKEN_ID_1, VALUE_1, IPFS_URI());
+    collection.mint_edition(recipient, VALUE_1, IPFS_URI());
 
     assert_eq!(collection.get_token_registered_at(TOKEN_ID_1), mock_timestamp);
 }
@@ -262,7 +262,7 @@ fn test_mint_item_uri_stored() {
     let recipient = deploy_receiver();
 
     cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    collection.mint_item(recipient, TOKEN_ID_1, VALUE_1, IPFS_URI());
+    collection.mint_edition(recipient, VALUE_1, IPFS_URI());
 
     let metadata = IERC1155MetadataURIDispatcher { contract_address: address };
     assert_eq!(metadata.uri(TOKEN_ID_1), IPFS_URI());
@@ -277,7 +277,7 @@ fn test_get_token_data_all_fields() {
     let mock_timestamp: u64 = 1700000000;
     cheat_block_timestamp(address, mock_timestamp, CheatSpan::TargetCalls(1));
     cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    collection.mint_item(recipient, TOKEN_ID_1, VALUE_1, IPFS_URI());
+    collection.mint_edition(recipient, VALUE_1, IPFS_URI());
 
     let token_data = collection.get_token_data(TOKEN_ID_1);
     assert_eq!(token_data.token_id, TOKEN_ID_1);
@@ -297,7 +297,7 @@ fn test_mint_item_emits_ip_minted_event() {
     cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
 
     let mut spy = spy_events();
-    collection.mint_item(recipient, TOKEN_ID_1, VALUE_1, IPFS_URI());
+    collection.mint_edition(recipient, VALUE_1, IPFS_URI());
 
     spy
         .assert_emitted(
@@ -326,7 +326,7 @@ fn test_mint_item_not_owner() {
     let (collection, _) = deploy_collection(owner, BASE_URI());
     let recipient = deploy_receiver();
     // No cheat: caller defaults to zero (not owner)
-    collection.mint_item(recipient, TOKEN_ID_1, VALUE_1, IPFS_URI());
+    collection.mint_edition(recipient, VALUE_1, IPFS_URI());
 }
 
 #[test]
@@ -336,7 +336,7 @@ fn test_mint_item_zero_recipient() {
     let (collection, address) = deploy_collection(owner, BASE_URI());
 
     cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    collection.mint_item(ZERO(), TOKEN_ID_1, VALUE_1, IPFS_URI());
+    collection.mint_edition(ZERO(), VALUE_1, IPFS_URI());
 }
 
 #[test]
@@ -347,7 +347,7 @@ fn test_mint_item_zero_value_rejected() {
     let recipient = deploy_receiver();
 
     cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    collection.mint_item(recipient, TOKEN_ID_1, 0, IPFS_URI());
+    collection.mint_edition(recipient, 0, IPFS_URI());
 }
 
 #[test]
@@ -357,7 +357,7 @@ fn test_mint_item_bare_cid_allowed() {
     let recipient = deploy_receiver();
 
     cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    collection.mint_item(recipient, TOKEN_ID_1, VALUE_1, BARE_CID());
+    collection.mint_edition(recipient, VALUE_1, BARE_CID());
 
     let metadata = IERC1155MetadataURIDispatcher { contract_address: address };
     assert_eq!(metadata.uri(TOKEN_ID_1), BARE_CID());
@@ -370,7 +370,7 @@ fn test_mint_item_http_uri_allowed() {
     let recipient = deploy_receiver();
 
     cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    collection.mint_item(recipient, TOKEN_ID_1, VALUE_1, HTTP_URI());
+    collection.mint_edition(recipient, VALUE_1, HTTP_URI());
 
     let metadata = IERC1155MetadataURIDispatcher { contract_address: address };
     assert_eq!(metadata.uri(TOKEN_ID_1), HTTP_URI());
@@ -384,7 +384,7 @@ fn test_mint_item_empty_uri_rejected_for_new_token() {
     let recipient = deploy_receiver();
 
     cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    collection.mint_item(recipient, TOKEN_ID_1, VALUE_1, "");
+    collection.mint_edition(recipient, VALUE_1, "");
 }
 
 #[test]
@@ -395,10 +395,10 @@ fn test_mint_item_long_uri_rejected_for_new_token() {
     let recipient = deploy_receiver();
 
     cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    collection.mint_item(recipient, TOKEN_ID_1, VALUE_1, LONG_URI());
+    collection.mint_edition(recipient, VALUE_1, LONG_URI());
 }
 
-// ─── Subsequent mint of same token_id ─────────────────────────────────────────
+// ─── add_supply (re-supply an existing edition) ──────────────────────────────────
 
 #[test]
 fn test_remint_existing_token_increases_balance() {
@@ -408,11 +408,11 @@ fn test_remint_existing_token_increases_balance() {
 
     // First mint — stores provenance
     cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    collection.mint_item(recipient, TOKEN_ID_1, VALUE_1, IPFS_URI());
+    collection.mint_edition(recipient, VALUE_1, IPFS_URI());
 
-    // Second mint — provenance unchanged, balance increases
+    // add_supply — provenance unchanged, balance increases
     cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    collection.mint_item(recipient, TOKEN_ID_1, VALUE_2, IPFS_URI());
+    collection.add_supply(recipient, TOKEN_ID_1, VALUE_2);
 
     let erc1155 = IERC1155Dispatcher { contract_address: address };
     assert_eq!(erc1155.balance_of(recipient, TOKEN_ID_1), VALUE_1 + VALUE_2);
@@ -426,11 +426,11 @@ fn test_remint_existing_token_preserves_creator() {
     let recipient2 = deploy_receiver();
 
     cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    collection.mint_item(recipient, TOKEN_ID_1, VALUE_1, IPFS_URI());
+    collection.mint_edition(recipient, VALUE_1, IPFS_URI());
 
-    // Second mint to different address — creator (owner/caller) is still unchanged
+    // add_supply to a different address — creator (owner/caller) is still unchanged
     cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    collection.mint_item(recipient2, TOKEN_ID_1, VALUE_2, IPFS_URI());
+    collection.add_supply(recipient2, TOKEN_ID_1, VALUE_2);
 
     assert_eq!(collection.get_token_creator(TOKEN_ID_1), owner);
 }
@@ -442,142 +442,33 @@ fn test_remint_existing_token_preserves_uri() {
     let recipient = deploy_receiver();
 
     cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    collection.mint_item(recipient, TOKEN_ID_1, VALUE_1, IPFS_URI());
+    collection.mint_edition(recipient, VALUE_1, IPFS_URI());
 
     cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    collection.mint_item(recipient, TOKEN_ID_1, VALUE_2, IPFS_URI_2());
+    collection.add_supply(recipient, TOKEN_ID_1, VALUE_2);
 
     let metadata = IERC1155MetadataURIDispatcher { contract_address: address };
     assert_eq!(metadata.uri(TOKEN_ID_1), IPFS_URI()); // original URI preserved
 }
 
-// ─── batch_mint_item ───────────────────────────────────────────────────────────
-
 #[test]
-fn test_batch_mint_item() {
-    let owner = OWNER();
-    let (collection, address) = deploy_collection(owner, BASE_URI());
+#[should_panic(expected: 'Token does not exist')]
+fn test_add_supply_unknown_id_reverts() {
+    let (collection, _) = deploy_collection(OWNER(), BASE_URI());
     let recipient = deploy_receiver();
-
-    let token_ids: Array<u256> = array![TOKEN_ID_1, TOKEN_ID_2, TOKEN_ID_3];
-    let values: Array<u256> = array![VALUE_1, VALUE_2, VALUE_3];
-    let uris: Array<ByteArray> = array![IPFS_URI(), AR_URI(), IPFS_URI_2()];
-
-    cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    collection.batch_mint_item(recipient, token_ids.span(), values.span(), uris);
-
-    let erc1155 = IERC1155Dispatcher { contract_address: address };
-    assert_eq!(erc1155.balance_of(recipient, TOKEN_ID_1), VALUE_1);
-    assert_eq!(erc1155.balance_of(recipient, TOKEN_ID_2), VALUE_2);
-    assert_eq!(erc1155.balance_of(recipient, TOKEN_ID_3), VALUE_3);
-}
-
-#[test]
-fn test_batch_mint_item_stores_per_token_uri() {
-    let owner = OWNER();
-    let (collection, address) = deploy_collection(owner, BASE_URI());
-    let recipient = deploy_receiver();
-
-    let token_ids: Array<u256> = array![TOKEN_ID_1, TOKEN_ID_2];
-    let values: Array<u256> = array![VALUE_1, VALUE_2];
-    let uris: Array<ByteArray> = array![IPFS_URI(), AR_URI()];
-
-    cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    collection.batch_mint_item(recipient, token_ids.span(), values.span(), uris);
-
-    let metadata = IERC1155MetadataURIDispatcher { contract_address: address };
-    assert_eq!(metadata.uri(TOKEN_ID_1), IPFS_URI());
-    assert_eq!(metadata.uri(TOKEN_ID_2), AR_URI());
-}
-
-#[test]
-fn test_batch_mint_item_creator_is_caller() {
-    let owner = OWNER();
-    let (collection, address) = deploy_collection(owner, BASE_URI());
-    let recipient = deploy_receiver();
-
-    let token_ids: Array<u256> = array![TOKEN_ID_1, TOKEN_ID_2];
-    let values: Array<u256> = array![VALUE_1, VALUE_2];
-    let uris: Array<ByteArray> = array![IPFS_URI(), AR_URI()];
-
-    cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    collection.batch_mint_item(recipient, token_ids.span(), values.span(), uris);
-
-    assert_eq!(collection.get_token_creator(TOKEN_ID_1), owner);
-    assert_eq!(collection.get_token_creator(TOKEN_ID_2), owner);
+    cheat_caller_address(collection.contract_address, OWNER(), CheatSpan::TargetCalls(1));
+    collection.add_supply(recipient, 999, VALUE_1);
 }
 
 #[test]
 #[should_panic(expected: 'Caller is not the owner')]
-fn test_batch_mint_item_not_owner() {
-    let owner = OWNER();
-    let (collection, _) = deploy_collection(owner, BASE_URI());
+fn test_add_supply_non_owner_reverts() {
+    let (collection, address) = deploy_collection(OWNER(), BASE_URI());
     let recipient = deploy_receiver();
-
-    let token_ids: Array<u256> = array![TOKEN_ID_1];
-    let values: Array<u256> = array![VALUE_1];
-    let uris: Array<ByteArray> = array![IPFS_URI()];
-
-    collection.batch_mint_item(recipient, token_ids.span(), values.span(), uris);
-}
-
-#[test]
-#[should_panic(expected: 'Recipient is zero address')]
-fn test_batch_mint_item_zero_recipient() {
-    let owner = OWNER();
-    let (collection, address) = deploy_collection(owner, BASE_URI());
-
-    let token_ids: Array<u256> = array![TOKEN_ID_1];
-    let values: Array<u256> = array![VALUE_1];
-    let uris: Array<ByteArray> = array![IPFS_URI()];
-
-    cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    collection.batch_mint_item(ZERO(), token_ids.span(), values.span(), uris);
-}
-
-#[test]
-#[should_panic(expected: 'Value must be > 0')]
-fn test_batch_mint_item_zero_value_rejected() {
-    let owner = OWNER();
-    let (collection, address) = deploy_collection(owner, BASE_URI());
-    let recipient = deploy_receiver();
-
-    let token_ids: Array<u256> = array![TOKEN_ID_1];
-    let values: Array<u256> = array![0]; // zero value
-    let uris: Array<ByteArray> = array![IPFS_URI()];
-
-    cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    collection.batch_mint_item(recipient, token_ids.span(), values.span(), uris);
-}
-
-#[test]
-#[should_panic(expected: 'Array length mismatch')]
-fn test_batch_mint_item_ids_values_mismatch() {
-    let owner = OWNER();
-    let (collection, address) = deploy_collection(owner, BASE_URI());
-    let recipient = deploy_receiver();
-
-    let token_ids: Array<u256> = array![TOKEN_ID_1, TOKEN_ID_2];
-    let values: Array<u256> = array![VALUE_1]; // shorter
-    let uris: Array<ByteArray> = array![IPFS_URI(), AR_URI()];
-
-    cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    collection.batch_mint_item(recipient, token_ids.span(), values.span(), uris);
-}
-
-#[test]
-#[should_panic(expected: 'Array length mismatch')]
-fn test_batch_mint_item_ids_uris_mismatch() {
-    let owner = OWNER();
-    let (collection, address) = deploy_collection(owner, BASE_URI());
-    let recipient = deploy_receiver();
-
-    let token_ids: Array<u256> = array![TOKEN_ID_1, TOKEN_ID_2];
-    let values: Array<u256> = array![VALUE_1, VALUE_2];
-    let uris: Array<ByteArray> = array![IPFS_URI()]; // shorter
-
-    cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    collection.batch_mint_item(recipient, token_ids.span(), values.span(), uris);
+    cheat_caller_address(address, OWNER(), CheatSpan::TargetCalls(1));
+    let id = collection.mint_edition(recipient, VALUE_1, IPFS_URI());
+    cheat_caller_address(address, USER1(), CheatSpan::TargetCalls(1));
+    collection.add_supply(recipient, id, VALUE_2);
 }
 
 // ─── Provenance query guards ───────────────────────────────────────────────────
@@ -616,7 +507,7 @@ fn test_transfer_between_receivers() {
     let receiver2 = deploy_receiver();
 
     cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    collection.mint_item(receiver1, TOKEN_ID_1, VALUE_1, IPFS_URI());
+    collection.mint_edition(receiver1, VALUE_1, IPFS_URI());
 
     let erc1155 = IERC1155Dispatcher { contract_address: address };
     cheat_caller_address(address, receiver1, CheatSpan::TargetCalls(1));
@@ -641,9 +532,9 @@ fn test_multiple_token_ids_independent_balances() {
     let recipient = deploy_receiver();
 
     cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    collection.mint_item(recipient, TOKEN_ID_1, VALUE_1, IPFS_URI());
+    collection.mint_edition(recipient, VALUE_1, IPFS_URI());
     cheat_caller_address(address, owner, CheatSpan::TargetCalls(1));
-    collection.mint_item(recipient, TOKEN_ID_2, VALUE_2, AR_URI());
+    collection.mint_edition(recipient, VALUE_2, AR_URI());
 
     let erc1155 = IERC1155Dispatcher { contract_address: address };
     assert_eq!(erc1155.balance_of(recipient, TOKEN_ID_1), VALUE_1);

--- a/contracts/IP-Programmable-ERC1155-Collections/src/tests/IPCollectionTest.cairo
+++ b/contracts/IP-Programmable-ERC1155-Collections/src/tests/IPCollectionTest.cairo
@@ -398,6 +398,21 @@ fn test_mint_item_long_uri_rejected_for_new_token() {
     collection.mint_edition(recipient, VALUE_1, LONG_URI());
 }
 
+#[test]
+fn test_total_editions_and_token_exists() {
+    let (collection, _) = deploy_collection(OWNER(), BASE_URI());
+    let recipient = deploy_receiver();
+    assert_eq!(collection.total_editions(), 0);
+    assert!(!collection.token_exists(1));
+    cheat_caller_address(collection.contract_address, OWNER(), CheatSpan::TargetCalls(2));
+    collection.mint_edition(recipient, VALUE_1, IPFS_URI());
+    collection.mint_edition(recipient, VALUE_1, IPFS_URI_2());
+    assert_eq!(collection.total_editions(), 2);
+    assert!(collection.token_exists(1));
+    assert!(collection.token_exists(2));
+    assert!(!collection.token_exists(3));
+}
+
 // ─── add_supply (re-supply an existing edition) ──────────────────────────────────
 
 #[test]

--- a/contracts/IP-Programmable-ERC1155-Collections/src/tests/IPCollectionTest.cairo
+++ b/contracts/IP-Programmable-ERC1155-Collections/src/tests/IPCollectionTest.cairo
@@ -189,11 +189,11 @@ fn test_uri_minted_token_returns_per_token_uri() {
     assert_eq!(metadata.uri(TOKEN_ID_1), IPFS_URI());
 }
 
-// ─── mint_item
+// ─── mint_edition (URI handling)
 // ─────────────────────────────────────────────────────────────────
 
 #[test]
-fn test_mint_item_ipfs_uri() {
+fn test_mint_edition_ipfs_uri() {
     let owner = OWNER();
     let (collection, address) = deploy_collection(owner, BASE_URI());
     let recipient = deploy_receiver();
@@ -206,7 +206,7 @@ fn test_mint_item_ipfs_uri() {
 }
 
 #[test]
-fn test_mint_item_ar_uri() {
+fn test_mint_edition_ar_uri() {
     let owner = OWNER();
     let (collection, address) = deploy_collection(owner, BASE_URI());
     let recipient = deploy_receiver();
@@ -219,7 +219,7 @@ fn test_mint_item_ar_uri() {
 }
 
 #[test]
-fn test_mint_item_future_uri_scheme() {
+fn test_mint_edition_future_uri_scheme() {
     let owner = OWNER();
     let (collection, address) = deploy_collection(owner, BASE_URI());
     let recipient = deploy_receiver();
@@ -232,7 +232,7 @@ fn test_mint_item_future_uri_scheme() {
 }
 
 #[test]
-fn test_mint_item_creator_is_caller_not_recipient() {
+fn test_mint_edition_creator_is_caller_not_recipient() {
     // The IP creator is the collection owner (caller), not the token recipient.
     // This correctly captures the Berne Convention author — the artist who mints, not the buyer.
     let owner = OWNER();
@@ -246,7 +246,7 @@ fn test_mint_item_creator_is_caller_not_recipient() {
 }
 
 #[test]
-fn test_mint_item_stores_registered_at() {
+fn test_mint_edition_stores_registered_at() {
     let owner = OWNER();
     let (collection, address) = deploy_collection(owner, BASE_URI());
     let recipient = deploy_receiver();
@@ -260,7 +260,7 @@ fn test_mint_item_stores_registered_at() {
 }
 
 #[test]
-fn test_mint_item_uri_stored() {
+fn test_mint_edition_uri_stored() {
     let owner = OWNER();
     let (collection, address) = deploy_collection(owner, BASE_URI());
     let recipient = deploy_receiver();
@@ -291,7 +291,7 @@ fn test_get_token_data_all_fields() {
 }
 
 #[test]
-fn test_mint_item_emits_ip_minted_event() {
+fn test_mint_edition_emits_ip_minted_event() {
     let owner = OWNER();
     let (collection, address) = deploy_collection(owner, BASE_URI());
     let recipient = deploy_receiver();
@@ -325,7 +325,7 @@ fn test_mint_item_emits_ip_minted_event() {
 
 #[test]
 #[should_panic(expected: 'Caller is not the owner')]
-fn test_mint_item_not_owner() {
+fn test_mint_edition_not_owner() {
     let owner = OWNER();
     let (collection, _) = deploy_collection(owner, BASE_URI());
     let recipient = deploy_receiver();
@@ -335,7 +335,7 @@ fn test_mint_item_not_owner() {
 
 #[test]
 #[should_panic(expected: 'Recipient is zero address')]
-fn test_mint_item_zero_recipient() {
+fn test_mint_edition_zero_recipient() {
     let owner = OWNER();
     let (collection, address) = deploy_collection(owner, BASE_URI());
 
@@ -345,7 +345,7 @@ fn test_mint_item_zero_recipient() {
 
 #[test]
 #[should_panic(expected: 'Value must be > 0')]
-fn test_mint_item_zero_value_rejected() {
+fn test_mint_edition_zero_value_rejected() {
     let owner = OWNER();
     let (collection, address) = deploy_collection(owner, BASE_URI());
     let recipient = deploy_receiver();
@@ -355,7 +355,7 @@ fn test_mint_item_zero_value_rejected() {
 }
 
 #[test]
-fn test_mint_item_bare_cid_allowed() {
+fn test_mint_edition_bare_cid_allowed() {
     let owner = OWNER();
     let (collection, address) = deploy_collection(owner, BASE_URI());
     let recipient = deploy_receiver();
@@ -368,7 +368,7 @@ fn test_mint_item_bare_cid_allowed() {
 }
 
 #[test]
-fn test_mint_item_http_uri_allowed() {
+fn test_mint_edition_http_uri_allowed() {
     let owner = OWNER();
     let (collection, address) = deploy_collection(owner, BASE_URI());
     let recipient = deploy_receiver();
@@ -382,7 +382,7 @@ fn test_mint_item_http_uri_allowed() {
 
 #[test]
 #[should_panic(expected: 'Invalid URI length')]
-fn test_mint_item_empty_uri_rejected_for_new_token() {
+fn test_mint_edition_empty_uri_rejected_for_new_token() {
     let owner = OWNER();
     let (collection, address) = deploy_collection(owner, BASE_URI());
     let recipient = deploy_receiver();
@@ -393,7 +393,7 @@ fn test_mint_item_empty_uri_rejected_for_new_token() {
 
 #[test]
 #[should_panic(expected: 'Invalid URI length')]
-fn test_mint_item_long_uri_rejected_for_new_token() {
+fn test_mint_edition_long_uri_rejected_for_new_token() {
     let owner = OWNER();
     let (collection, address) = deploy_collection(owner, BASE_URI());
     let recipient = deploy_receiver();

--- a/contracts/IP-Programmable-ERC1155-Collections/src/tests/IPCollectionTest.cairo
+++ b/contracts/IP-Programmable-ERC1155-Collections/src/tests/IPCollectionTest.cairo
@@ -413,6 +413,63 @@ fn test_total_editions_and_token_exists() {
     assert!(!collection.token_exists(3));
 }
 
+// ─── batch_mint_edition ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_batch_mint_edition_sequential() {
+    let (collection, address) = deploy_collection(OWNER(), BASE_URI());
+    let recipient = deploy_receiver();
+    cheat_caller_address(address, OWNER(), CheatSpan::TargetCalls(1));
+    let ids = collection
+        .batch_mint_edition(
+            recipient, array![VALUE_1, VALUE_2].span(), array![IPFS_URI(), IPFS_URI_2()],
+        );
+    assert_eq!(*ids.at(0), 1);
+    assert_eq!(*ids.at(1), 2);
+    assert_eq!(collection.total_editions(), 2);
+    let erc1155 = IERC1155Dispatcher { contract_address: address };
+    assert_eq!(erc1155.balance_of(recipient, 1), VALUE_1);
+    assert_eq!(erc1155.balance_of(recipient, 2), VALUE_2);
+    let meta = IERC1155MetadataURIDispatcher { contract_address: address };
+    assert_eq!(meta.uri(2), IPFS_URI_2());
+}
+
+#[test]
+fn test_batch_then_single_continues_sequence() {
+    let (collection, _) = deploy_collection(OWNER(), BASE_URI());
+    let recipient = deploy_receiver();
+    cheat_caller_address(collection.contract_address, OWNER(), CheatSpan::TargetCalls(2));
+    collection.batch_mint_edition(recipient, array![VALUE_1, VALUE_1].span(), array![IPFS_URI(), AR_URI()]);
+    let next = collection.mint_edition(recipient, VALUE_1, HTTP_URI());
+    assert_eq!(next, 3);
+}
+
+#[test]
+#[should_panic(expected: 'Recipient is zero address')]
+fn test_batch_mint_edition_zero_recipient() {
+    let (collection, address) = deploy_collection(OWNER(), BASE_URI());
+    cheat_caller_address(address, OWNER(), CheatSpan::TargetCalls(1));
+    collection.batch_mint_edition(ZERO(), array![VALUE_1].span(), array![IPFS_URI()]);
+}
+
+#[test]
+#[should_panic(expected: 'Array length mismatch')]
+fn test_batch_mint_edition_length_mismatch() {
+    let (collection, address) = deploy_collection(OWNER(), BASE_URI());
+    let recipient = deploy_receiver();
+    cheat_caller_address(address, OWNER(), CheatSpan::TargetCalls(1));
+    collection.batch_mint_edition(recipient, array![VALUE_1, VALUE_2].span(), array![IPFS_URI()]);
+}
+
+#[test]
+#[should_panic(expected: 'Caller is not the owner')]
+fn test_batch_mint_edition_not_owner() {
+    let (collection, address) = deploy_collection(OWNER(), BASE_URI());
+    let recipient = deploy_receiver();
+    cheat_caller_address(address, USER1(), CheatSpan::TargetCalls(1));
+    collection.batch_mint_edition(recipient, array![VALUE_1].span(), array![IPFS_URI()]);
+}
+
 // ─── add_supply (re-supply an existing edition) ──────────────────────────────────
 
 #[test]

--- a/contracts/IP-Programmable-ERC1155-Collections/src/tests/IPCollectionTest.cairo
+++ b/contracts/IP-Programmable-ERC1155-Collections/src/tests/IPCollectionTest.cairo
@@ -790,3 +790,40 @@ fn test_default_royalty_info_returns_denominator() {
     assert_eq!(numerator, 750);
     assert_eq!(denominator, 10_000);
 }
+
+// ─── mint_edition (on-chain sequential ids) ──────────────────────────────────────
+
+#[test]
+fn test_mint_edition_assigns_sequential_ids() {
+    let (collection, _) = deploy_collection(OWNER(), BASE_URI());
+    let recipient = deploy_receiver();
+    cheat_caller_address(collection.contract_address, OWNER(), CheatSpan::TargetCalls(3));
+    let id1 = collection.mint_edition(recipient, VALUE_1, IPFS_URI());
+    let id2 = collection.mint_edition(recipient, VALUE_1, IPFS_URI_2());
+    let id3 = collection.mint_edition(recipient, VALUE_1, AR_URI());
+    assert_eq!(id1, 1);
+    assert_eq!(id2, 2);
+    assert_eq!(id3, 3);
+}
+
+#[test]
+fn test_mint_edition_records_provenance_and_supply() {
+    let (collection, address) = deploy_collection(OWNER(), BASE_URI());
+    let recipient = deploy_receiver();
+    cheat_caller_address(address, OWNER(), CheatSpan::TargetCalls(1));
+    let id = collection.mint_edition(recipient, VALUE_1, IPFS_URI());
+    assert_eq!(collection.get_token_creator(id), OWNER());
+    let erc1155 = IERC1155Dispatcher { contract_address: address };
+    assert_eq!(erc1155.balance_of(recipient, id), VALUE_1);
+    let meta = IERC1155MetadataURIDispatcher { contract_address: address };
+    assert_eq!(meta.uri(id), IPFS_URI());
+}
+
+#[test]
+#[should_panic(expected: 'Caller is not the owner')]
+fn test_mint_edition_non_owner_reverts() {
+    let (collection, _) = deploy_collection(OWNER(), BASE_URI());
+    let recipient = deploy_receiver();
+    cheat_caller_address(collection.contract_address, USER1(), CheatSpan::TargetCalls(1));
+    collection.mint_edition(recipient, VALUE_1, IPFS_URI());
+}


### PR DESCRIPTION
## Summary

Gives the ERC-1155 collection an on-chain edition counter (like the ERC-721 registry already has), so editions get clean **sequential ids assigned atomically on-chain** instead of app-side `Date.now()*1e6+random`. Also removes the silent supply-merge footgun and makes the factory immutable/ownerless.

**Why:** `mint_item` took a caller-supplied id and `_mint_single` silently **merged** a duplicate id into the existing token's supply (no revert) — so any app-side id scheme risked fusing two artworks. The contract must own id assignment.

### Contract changes (`IPCollection`, v0.3.0)
- **`next_token_id` counter** (init 1) + **`mint_edition(to, value, uri) -> u256`** — new edition, sequential id, records provenance, returns the id.
- **`batch_mint_edition(to, values, uris) -> Span<u256>`** — N editions, sequential ids.
- **`add_supply(to, existing_id, value)`** — "more copies of an edition"; **reverts if the id doesn't exist**. Replaces the merge-prone `mint_item`/`batch_mint_item` (both removed).
- **`total_editions()` + `token_exists(id)`** reads.
- ERC-2981 royalties unchanged (already built in).

### Factory changes (`IPCollectionFactory`, v0.3.0)
- **Removed `update_collection_class_hash` + Ownable** → fully immutable, ownerless. The collection class hash is fixed at deploy; evolution = deploy a new factory.

## Test plan
- `snforge test` → **69 passed, 0 failed**. New coverage: sequential ids, provenance/supply, owner gating, `add_supply` (balance/creator/uri unchanged, unknown-id reverts), batch (sequential, continues sequence, mismatch/zero/owner guards), `total_editions`/`token_exists`, ownerless-factory deploy.
- `scarb build` clean; `scarb fmt` applied; zero `mint_item`/`update_collection_class_hash` references remain.

## Next (separate, gated on this)
Audit → declare/deploy new class hash + ownerless factory → SDK (new address/ABI) → backend indexer (watch new factory) → dapp/io (`mint_edition`, read id from `IPMinted` event, delete the timestamp generator). Full rollout plan: `medialane-core/docs/superpowers/plans/2026-06-09-erc1155-sequential-token-ids.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)