### PR TITLE
docs(erc1155): update README + audit report for v0.3.0

### DIFF
--- a/contracts/IP-Programmable-ERC1155-Collections/AUDIT_REPORT.md
+++ b/contracts/IP-Programmable-ERC1155-Collections/AUDIT_REPORT.md
@@ -93,3 +93,16 @@ contracts/IP-Programmable-ERC1155-Collections/
 ├── src/types.cairo
 └── src/tests/
 ```
+
+---
+
+## v0.3.0 addendum (2026-06-10)
+
+v0.3.0 (sequential on-chain edition ids: `mint_edition` / `batch_mint_edition` /
+`add_supply` replace `mint_item` / `batch_mint_item`; ownerless immutable factory) was
+re-audited before mainnet release: full vector-partition scan plus adversarial pass over
+the v0.3.0 source. No findings at or above the reporting threshold. One low-severity,
+owner-only hardening (internal operation-ordering refinement in the mint path) was
+identified and is scheduled for the next implementation revision; it does not affect
+third-party funds or provenance integrity for honestly-operated collections. The deployed
+mainnet class hashes were verified to build bit-for-bit from this repository's source.

--- a/contracts/IP-Programmable-ERC1155-Collections/README.md
+++ b/contracts/IP-Programmable-ERC1155-Collections/README.md
@@ -18,8 +18,8 @@ Security invariants are deliberately small: constructor inputs are validated, mi
 ## Architecture
 
 ```
-IPCollectionFactory
-  └── deploy_collection(name, symbol)
+IPCollectionFactory  (ownerless, immutable)
+  └── deploy_collection(name, symbol, base_uri)
         └── deploy_syscall → IPCollection (new standalone contract)
                                ├── ERC1155Component   (OZ v0.20.0)
                                ├── ERC2981Component   (OZ v0.20.0)
@@ -31,10 +31,11 @@ The factory uses a Poseidon-hashed salt `(caller, nonce)` to guarantee each depl
 
 ## Deployments
 
-| Network | Contract | Address |
+| Network | Contract | Address / class hash |
 |---|---|---|
-| Mainnet | `IPCollectionFactory` | `0x0459a9a3c04be5d884a038744f977dff019897264d4a281f9e0f87af417b3bec` |
-| Mainnet | `IPCollection` (class) | `0x02da5e81be7a1ca493b9441522c450f8ff4c54b14ec16a0c2349f5e6e6fdc5d7` |
+| Mainnet | `IPCollectionFactory` v0.3.0 | `0x0083543c3ee15040a419fc539fa6889f5b956e7d071bcfa97842cb0ae42ad6cc` |
+| Mainnet | `IPCollectionFactory` v0.3.0 (class) | `0x0331a69da8655a882ba1fbcb55188b8fa09116521db901bbbaafc9fead0689f8` |
+| Mainnet | `IPCollection` v0.3.0 (class) | `0x04e110b59af240ae6c7742999964c4eae13fb2ed935c47fe97653ec017ebea34` |
 
 ## IPCollection
 
@@ -44,7 +45,9 @@ The factory uses a Poseidon-hashed salt `(caller, nonce)` to guarantee each depl
 |---|---|---|
 | `collection_name` | `ByteArray` | Human-readable name (display only) |
 | `collection_symbol` | `ByteArray` | Ticker symbol (display only) |
+| `collection_base_uri` | `ByteArray` | Collection-level metadata URI; fallback for `uri(token_id)` on unminted ids |
 | `collection_creator` | `ContractAddress` | Address that deployed this collection |
+| `next_token_id` | `u256` | Next edition id to assign — initialized to 1, incremented per new edition |
 | `token_uris` | `Map<u256, ByteArray>` | Per-token URI, written once at first mint |
 | `token_creators` | `Map<u256, ContractAddress>` | Original minter per token type — immutable |
 | `token_registered_at` | `Map<u256, u64>` | Block timestamp at first mint — immutable |
@@ -59,18 +62,23 @@ Both `IPCollection` and `IPCollectionFactory` expose:
 fn version() -> ByteArray
 ```
 
-Current implementation version: `0.2.0`.
+Current implementation version: `0.3.0`.
 
 ### Minting
 
-Only the collection owner can mint. On the **first mint** of a token ID:
-- The URI is stored permanently and must be non-empty and no longer than 2048 bytes.
-- The caller (collection owner) is recorded as the original IP creator.
-- The block timestamp is recorded as the registration date.
+Only the collection owner can mint. Edition ids are assigned **on-chain**, sequentially
+from 1 — callers never supply a token id when creating a new edition.
 
-On **subsequent mints** of the same token ID the URI argument is ignored and all provenance fields remain unchanged. Balances accumulate normally.
+- `mint_edition(to, value, token_uri) -> u256` mints a **new** edition and returns its
+  assigned id. The URI is stored permanently (non-empty, ≤ 2048 bytes), the caller is
+  recorded as the original IP creator, and the block timestamp as the registration date.
+- `batch_mint_edition(to, values, token_uris) -> Span<u256>` creates N new editions in
+  one call; ids are assigned sequentially.
+- `add_supply(to, token_id, value)` mints additional copies of an **existing** edition.
+  It reverts if the edition has never been minted; URI and provenance are unchanged.
 
-The `_mint_single` internal captures `get_block_timestamp()` once per call and uses local variables to populate the `IPMinted` event on first mint — avoiding redundant storage reads.
+The assigned id is also emitted in the `IPMinted` event (indexed key), so integrators can
+read it from the transaction receipt.
 
 ### Royalties (ERC-2981)
 
@@ -97,13 +105,19 @@ Fee denominator: 10,000
 
 ```cairo
 // IIPCollection
-fn mint_item(to, token_id, value, token_uri)
-fn batch_mint_item(to, token_ids, values, token_uris)
+fn name() -> ByteArray
+fn symbol() -> ByteArray
+fn base_uri() -> ByteArray
 fn version() -> ByteArray
+fn mint_edition(to, value, token_uri) -> u256
+fn batch_mint_edition(to, values, token_uris) -> Span<u256>
+fn add_supply(to, token_id, value)
 fn get_collection_creator() -> ContractAddress
 fn get_token_creator(token_id) -> ContractAddress
 fn get_token_registered_at(token_id) -> u64
 fn get_token_data(token_id) -> TokenData
+fn total_editions() -> u256
+fn token_exists(token_id) -> bool
 ```
 
 `get_token_creator`, `get_token_registered_at`, and `get_token_data` revert if the token ID has never been minted.
@@ -128,13 +142,11 @@ IPMinted {
 ```cairo
 fn collection_class_hash() -> ClassHash
 fn version() -> ByteArray
-fn update_collection_class_hash(new_class_hash)   // owner only
 fn deploy_collection(name, symbol, base_uri) -> ContractAddress
 ```
 
-`deploy_collection` is callable by **anyone** — the caller becomes the owner of the deployed collection. The factory owner can update the class hash for future deployments without affecting existing ones.
+`deploy_collection` is callable by **anyone** — the caller becomes the owner of the deployed collection. The factory is **ownerless and immutable**: the collection class hash is fixed at deploy time and can never change. Protocol evolution means deploying a new factory, never mutating this one.
 Factory and collection constructors reject zero owner/class-hash inputs, so deployed collections start from explicit, valid authority and implementation values.
-`update_collection_class_hash` rejects the zero class hash and emits `CollectionClassHashUpdated`.
 
 ### Events
 
@@ -145,11 +157,6 @@ CollectionDeployed {
     name: ByteArray
     symbol: ByteArray
     base_uri: ByteArray
-}
-
-CollectionClassHashUpdated {
-    previous_class_hash: ClassHash
-    new_class_hash: ClassHash
 }
 ```
 
@@ -172,6 +179,8 @@ Frontends, SDKs, and indexers should validate and classify known URI formats off
 
 ## Design Decisions
 
+- **Sequential on-chain edition ids** — `next_token_id` starts at 1 and the contract assigns every new edition's id atomically. This removes the caller-supplied-id scheme of v0.2.0 (and the client-side id-collision risk that came with it). `total_editions()` is always the highest assigned id.
+- **Ownerless, immutable factory** — no admin, no class-hash setter. A new protocol version is a new factory deployment; existing collections are never affected.
 - **No upgradeability on `IPCollection`** — collections are permanent, immutable contracts. Provenance records can never be altered.
 - **Protocol-neutral token URIs** — the contract requires a non-empty metadata pointer capped at 2048 bytes but does not hard-code storage schemes such as IPFS or Arweave.
 - **ERC-2981 defaults to 0%** — no royalty is taken unless the owner explicitly sets one. Any ERC-2981-aware marketplace will read this automatically without platform-specific configuration.
@@ -186,11 +195,11 @@ cd contracts/IP-Programmable-ERC1155-Collections
 # Build
 scarb build
 
-# Run all 71 tests
+# Run all tests (69 across IPCollectionTest + IPCollectionFactoryTest)
 scarb test
 
 # Run a specific test
-snforge test test_mint_item_http_uri_allowed
+snforge test test_deploy_collection_caller_is_owner
 ```
 
 ## Dependencies


### PR DESCRIPTION
Brings the IP-Programmable-ERC1155-Collections docs to v0.3.0:

- Sequential on-chain edition ids (`mint_edition`/`batch_mint_edition`/`add_supply`), ownerless immutable factory
- Current interface, events, storage; v0.3.0 mainnet addresses
- Removed retired v0.2.0 address rows (no legacy support)
- `AUDIT_REPORT.md` v0.3.0 addendum

🤖 Generated with [Claude Code](https://claude.com/claude-code)