### PR TITLE
redesign(IP-Subscription): v2 — permissionless, ownerless, paid-time-inviolable

### DIFF
--- a/contracts/IP-Subscription/AUDIT_REPORT.md
+++ b/contracts/IP-Subscription/AUDIT_REPORT.md
@@ -1,4 +1,66 @@
-# IP Subscription Audit And Remediation Report
+# IP Subscription — v2 Redesign Audit (2026-06-10)
+
+**Date:** 2026-06-10
+**Scope:** Principle-conformance audit of the post-2026-05-23 implementation, followed by the v2 redesign in this tree.
+**Result:** v2 implemented; `scarb build` clean; `snforge test` 27 passed, 0 failed.
+
+## Why a v2
+
+The 2026-05-23 remediation produced a sound state machine (payment collection,
+expiry-derived status, sequential IDs, CEI ordering — all verified again before
+this redesign; 22/22 legacy tests passed). The remaining findings were
+conformance gaps against the Mediolano principles, which are stricter than what
+that audit measured:
+
+| # | Severity | Finding | v2 resolution |
+| --- | --- | --- | --- |
+| A1 | High (ownerless primitives) | Contract had an `owner` who alone could create plans — a per-creator, admin-gated deployment, unlike siblings `IP-Club` / `IP-Time-Capsule` | Owner removed. `create_plan` permissionless; `plan.creator` recorded per plan; only the plan creator can toggle that plan |
+| A2 | Medium (data minimization) | `subscriber_plan_ids` stored an enumerable on-chain subscriber roster serving only a convenience view; unbounded Vec | Removed. Indexers rebuild views from keyed events; data not held cannot be compelled |
+| A3 | Low | `tier: felt252` stored but never enforced — display data in storage | Removed; tier naming belongs in the plan's content-addressed `metadata_uri` |
+| B1 | Medium | `unsubscribe` set `expires_at = now`, forfeiting access the subscriber had paid for; with no on-chain auto-renew there is nothing to cancel | Function removed. Paid time always runs to expiry; no code path can shorten it |
+| B2 | Medium | `switch_subscription` had the same forfeiture (instant kill, zero credit, full new price) and duplicated `subscribe` | Function removed; account abstraction composes the same outcome as a multicall |
+| B3 | Low | Renewal stacking lets subscribers prepay indefinitely at the plan's immutable price | Kept, now documented as intended (terms immutability makes it safe) |
+| B4 | Low | Deactivation semantics were implicit | Decided + tested: `set_plan_active(false)` blocks new subscriptions **and** renewals; existing paid access is preserved (`test_deactivation_preserves_paid_access`) |
+| B5 | Info | Manual reentrancy lock was redundant (CEI already final before the external call) and cost two storage writes per paid op; records duplicated their own map keys | Lock removed with rationale tested (`test_reentrant_payment_token_is_isolated`: a malicious token reenters under its own caller context and can only subscribe itself); `SubscriptionRecord` reduced to `{ started_at, expires_at }` |
+
+## v2 invariants
+
+1. **Permissionless**: any caller can create a plan; any caller can subscribe to an active plan.
+2. **Ownerless / immutable**: no contract owner, no admin, no upgrade path, no fee. Plan economic terms never change; new terms = new plan.
+3. **Paid time is inviolable**: no function — including the plan creator's — can reduce an existing `expires_at`.
+4. **Disjoint verbs**: `subscribe` requires no active subscription; `renew_subscription` requires one. Exactly one of the two applies at any moment.
+5. **CEI**: subscription state is final before the ERC-20 `transfer_from`; a reverting payment reverts the whole transaction.
+6. **Minimal storage**: a subscription is two `u64` timestamps; existence is `expires_at != 0`; no enumerable rosters.
+
+## Interface changes (v1 → v2)
+
+- Removed: `unsubscribe`, `switch_subscription`, `get_owner`, `get_user_plan_ids`, constructor `owner` arg, `tier` param.
+- Changed: `PlanRecord` gains `creator`, drops `id`/`tier`; `SubscriptionRecord` is `{ started_at, expires_at }`; `renew_subscription` requires an *active* subscription (expired ones restart via `subscribe`).
+- New SRC5 ID (interface changed): `0x013f7d8dc8964bc1dc290304c1f2641165381c97e48c9f1497f90a93f7d513ac` = `starknet_keccak("mediolano.ip-subscription.v2")`.
+
+## Verification
+
+```bash
+scarb fmt && scarb build   # clean
+snforge test               # 27 passed, 0 failed
+```
+
+Coverage highlights: permissionless creation by two creators; creator-only
+toggle; deactivation blocking subscribe + renew while preserving paid access;
+expiry boundary (`expires_at` second inclusive); renewal stacking; paid
+subscribe/renew balance assertions; allowance-failure revert; reentrant-token
+isolation; SRC5 discovery; missing-record reverts.
+
+## Production recommendation
+
+Materially smaller surface than v1 (4 state-changing functions, no admin
+paths). Before mainnet deployment: external review, deployment rehearsal
+(declare/deploy, verify class hash), and registry/doctrine review for the
+service entry. The prior v1 report below is retained for history.
+
+---
+
+# IP Subscription Audit And Remediation Report (v1, historical)
 
 **Date:** 2026-05-23
 **Package:** `contracts/IP-Subscription`

--- a/contracts/IP-Subscription/README.md
+++ b/contracts/IP-Subscription/README.md
@@ -1,11 +1,37 @@
 # IP Subscription
 
-`IP-Subscription` is a Starknet smart contract for time-bound access plans. It lets a creator deploy a subscription service, create plans, and let users subscribe, renew, cancel, or switch plans.
+`IP-Subscription` is a permissionless Starknet contract for prepaid, time-bound
+access plans. One immutable deployment serves every creator: anyone can create
+a plan; subscribers pay the plan's recipient directly and receive access until
+an explicit expiry.
 
-The protocol is designed as the subscription sibling of `IP-Club`:
+The protocol is the subscription sibling of `IP-Club`:
 
 - `IP-Club`: non-transferable membership access.
 - `IP-Subscription`: time-bound access with explicit expiry and renewal.
+
+## Design (v2, 2026-06-10)
+
+The v2 redesign aligns the contract with the Mediolano principles
+(permissionless, ownerless, immutable, zero-fee, minimal data):
+
+- **No contract owner.** `create_plan` is open to any caller; the plan's
+  creator is recorded per plan and is the only address that can toggle that
+  plan's `active` flag. The contract itself has no admin, no upgrade path, and
+  takes no fee.
+- **Paid time is inviolable.** Nothing in the contract can shorten a paid
+  period — including the plan creator. Deactivating a plan stops new
+  subscriptions and renewals (no new money), but existing access always runs
+  to its expiry.
+- **Disjoint verbs.** `subscribe` starts a period when none is active;
+  `renew_subscription` extends an active one from its current expiry. There is
+  no `unsubscribe` (prepaid access has nothing to cancel on-chain — removing
+  it removed the only path that could forfeit paid time) and no
+  `switch_subscription` (account abstraction composes it as a multicall).
+- **Minimal on-chain data.** A subscription is two timestamps keyed by
+  `(subscriber, plan_id)`. There is no enumerable subscriber roster; indexers
+  rebuild views from keyed events. Display data such as tier names lives in
+  the plan's content-addressed `metadata_uri`, not in storage.
 
 ## Service Asset Declaration
 
@@ -21,25 +47,12 @@ This service follows the shared doctrine in
 | `access_semantics` | `is_subscribed(subscriber, plan_id)` derives access from expiry |
 | `marketplace_visibility` | Service/event visibility; no asset listing yet |
 | `metadata_uri_policy` | `ipfs://` or `ar://` for plan metadata |
-| `src5_interface_id` | `IIP_SUBSCRIPTION_ID` |
+| `src5_interface_id` | `IIP_SUBSCRIPTION_ID` (`starknet_keccak("mediolano.ip-subscription.v2")`) |
 
-The current contract intentionally keeps access state as a plan-specific record
-rather than a tradable asset. If this service becomes asset-backed, the asset
-should be designed explicitly as a non-transferable receipt, transferable time
-pass, or ERC-1155 plan edition.
-
-## Features
-
-- Sequential plan IDs.
-- Explicit plan existence and active state.
-- Free plans.
-- Paid ERC-20 plans with direct payment to the configured recipient.
-- Plan-specific subscription records keyed by `(subscriber, plan_id)`.
-- Expiry-derived access checks.
-- Renewal from current expiry when still active, or from current time when expired.
-- Reentrancy guard for payment flows.
-- Keyed events for indexers.
-- SRC5 interface detection.
+The contract intentionally keeps access state as a plan-specific record rather
+than a tradable asset. If this service becomes asset-backed, the asset should
+be designed explicitly as a non-transferable receipt, transferable time pass,
+or ERC-1155 plan edition.
 
 ## Interface
 
@@ -47,83 +60,44 @@ pass, or ERC-1155 plan edition.
 fn create_plan(
     price: u256,
     duration: u64,
-    tier: felt252,
     payment_token: Option<ContractAddress>,
     recipient: ContractAddress,
     metadata_uri: ByteArray,
 ) -> u256;
 
-fn set_plan_active(plan_id: u256, active: bool);
-fn subscribe(plan_id: u256);
-fn renew_subscription(plan_id: u256);
-fn unsubscribe(plan_id: u256);
-fn switch_subscription(current_plan_id: u256, new_plan_id: u256);
+fn set_plan_active(plan_id: u256, active: bool); // plan creator only
+fn subscribe(plan_id: u256);                     // starts a period; collects payment
+fn renew_subscription(plan_id: u256);            // extends an active period from its expiry
 
 fn is_subscribed(subscriber: ContractAddress, plan_id: u256) -> bool;
 fn get_subscription(subscriber: ContractAddress, plan_id: u256) -> SubscriptionRecord;
 fn get_plan(plan_id: u256) -> PlanRecord;
 fn get_last_plan_id() -> u256;
-fn get_owner() -> ContractAddress;
-fn get_user_plan_ids(subscriber: ContractAddress) -> Array<u256>;
 ```
 
 Custom SRC5 interface ID:
 
 ```cairo
 IIP_SUBSCRIPTION_ID =
-0x02b8b00d09660d14a71dfb5dd9f0acd39174877cf4e400f727b397a385e61ae3
+0x013f7d8dc8964bc1dc290304c1f2641165381c97e48c9f1497f90a93f7d513ac
 ```
 
 ## Plan Rules
 
-Free plan:
+- Sequential plan IDs; plan economic terms (price, duration, token, recipient)
+  are immutable — new terms mean a new plan.
+- Free plans use `price = 0` and `payment_token = None`. Paid plans require an
+  ERC-20 token and transfer `price` from the subscriber to `recipient` inside
+  `subscribe`/`renew_subscription` (checks-effects-interactions; state is
+  final before the external call).
+- Renewing while active stacks duration onto the current expiry — subscribers
+  may prepay ahead at the plan's immutable price. This is intended.
+- Plan `metadata_uri` must be content-addressed (`ipfs://` or `ar://`) so the
+  record stays verifiable independently of any gateway.
 
-```text
-price = 0
-payment_token = Option::None
-recipient = non-zero creator/payment recipient
-metadata_uri = ipfs://... or ar://...
-```
-
-Paid plan:
-
-```text
-price > 0
-payment_token = Option::Some(erc20_address)
-recipient = non-zero creator/payment recipient
-metadata_uri = ipfs://... or ar://...
-```
-
-HTTP metadata is rejected.
-
-## Access Semantics
-
-A subscription is active when:
-
-```text
-record.exists && record.active && record.expires_at >= get_block_timestamp()
-```
-
-Unsubscribing sets `active = false` and moves `expires_at` to the unsubscribe timestamp.
-
-Renewing an active subscription extends from its current expiry. Renewing an expired subscription starts from the current block timestamp.
-
-## Development
+## Build & Test
 
 ```bash
-cd contracts/IP-Subscription
 scarb build
-snforge test
+snforge test   # 27 tests
 ```
-
-Tested baseline:
-
-| Package | Version |
-| --- | --- |
-| `starknet` | `2.12.0` |
-| `openzeppelin_*` | `0.20.0` |
-| `snforge_std` | `0.59.0` |
-
-## Status
-
-This package has been redesigned from the legacy prototype. It is still pre-production until it receives external security review and deployment rehearsal.

--- a/contracts/IP-Subscription/src/Subscription.cairo
+++ b/contracts/IP-Subscription/src/Subscription.cairo
@@ -118,11 +118,8 @@ pub mod Subscription {
             if price == 0 {
                 assert(payment_token.is_none(), 'Free plan cannot use token');
             } else {
-                let token = match payment_token {
-                    Option::Some(token) => token,
-                    Option::None => panic!("Paid plan requires token"),
-                };
-                assert(!token.is_zero(), 'Payment token is zero');
+                assert(payment_token.is_some(), 'Paid plan requires token');
+                assert(!payment_token.unwrap().is_zero(), 'Payment token is zero');
             }
 
             let plan_id = self.last_plan_id.read() + 1;
@@ -134,7 +131,6 @@ pub mod Subscription {
                 payment_token,
                 metadata_uri: metadata_uri.clone(),
                 active: true,
-                exists: true,
             };
 
             self.plans.entry(plan_id).write(plan);
@@ -159,7 +155,7 @@ pub mod Subscription {
 
         fn set_plan_active(ref self: ContractState, plan_id: u256, active: bool) {
             let mut plan = self.plans.entry(plan_id).read();
-            assert(plan.exists, 'Plan does not exist');
+            assert(!plan.creator.is_zero(), 'Plan does not exist');
             assert(get_caller_address() == plan.creator, 'Only plan creator');
 
             plan.active = active;
@@ -173,7 +169,7 @@ pub mod Subscription {
             assert(!caller.is_zero(), 'Subscriber is zero address');
 
             let plan = self.plans.entry(plan_id).read();
-            assert(plan.exists, 'Plan does not exist');
+            assert(!plan.creator.is_zero(), 'Plan does not exist');
             assert(plan.active, 'Plan is inactive');
 
             let now = get_block_timestamp();
@@ -197,7 +193,7 @@ pub mod Subscription {
             assert(!caller.is_zero(), 'Subscriber is zero address');
 
             let plan = self.plans.entry(plan_id).read();
-            assert(plan.exists, 'Plan does not exist');
+            assert(!plan.creator.is_zero(), 'Plan does not exist');
             assert(plan.active, 'Plan is inactive');
 
             let now = get_block_timestamp();
@@ -235,7 +231,7 @@ pub mod Subscription {
 
         fn get_plan(self: @ContractState, plan_id: u256) -> PlanRecord {
             let plan = self.plans.entry(plan_id).read();
-            assert(plan.exists, 'Plan does not exist');
+            assert(!plan.creator.is_zero(), 'Plan does not exist');
             plan
         }
 
@@ -246,11 +242,9 @@ pub mod Subscription {
 
     fn collect_payment(payer: ContractAddress, plan: @PlanRecord) {
         if *plan.price > 0 {
-            let payment_token = match *plan.payment_token {
-                Option::Some(token) => token,
-                Option::None => panic!("Payment token missing"),
-            };
-            let token = IERC20Dispatcher { contract_address: payment_token };
+            // create_plan guarantees a paid plan carries a non-zero payment
+            // token, and plan terms are immutable.
+            let token = IERC20Dispatcher { contract_address: (*plan.payment_token).unwrap() };
             let result = token.transfer_from(payer, *plan.recipient, *plan.price);
             assert(result, 'Token Transfer Failed');
         }

--- a/contracts/IP-Subscription/src/Subscription.cairo
+++ b/contracts/IP-Subscription/src/Subscription.cairo
@@ -1,11 +1,21 @@
+// IP-Subscription v2 — permissionless, ownerless, immutable.
+//
+// One deployment serves every creator: anyone can create a plan, and only a
+// plan's creator can manage that plan. There is no contract owner, no admin,
+// no upgrade path, and no fee taken by the contract. Payments flow directly
+// from subscriber to the plan's recipient.
+//
+// Subscriptions are prepaid, time-bound access: `subscribe` starts a period,
+// `renew_subscription` extends an active one. Paid time always runs to
+// expiry — nothing in this contract can confiscate it, including the plan
+// creator (deactivating a plan only stops new payments).
 #[starknet::contract]
 pub mod Subscription {
     use core::num::traits::Zero;
     use openzeppelin_introspection::src5::SRC5Component;
     use openzeppelin_token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
     use starknet::storage::{
-        Map, MutableVecTrait, StoragePathEntry, StoragePointerReadAccess, StoragePointerWriteAccess,
-        Vec, VecTrait,
+        Map, StoragePathEntry, StoragePointerReadAccess, StoragePointerWriteAccess,
     };
     use starknet::{ContractAddress, get_block_timestamp, get_caller_address};
     use crate::interface::{IIP_SUBSCRIPTION_ID, ISubscription};
@@ -21,12 +31,9 @@ pub mod Subscription {
     struct Storage {
         #[substorage(v0)]
         src5: SRC5Component::Storage,
-        owner: ContractAddress,
         last_plan_id: u256,
         plans: Map<u256, PlanRecord>,
         subscriptions: Map<(ContractAddress, u256), SubscriptionRecord>,
-        subscriber_plan_ids: Map<ContractAddress, Vec<u256>>,
-        subscription_locked: bool,
     }
 
     #[event]
@@ -37,9 +44,7 @@ pub mod Subscription {
         PlanCreated: PlanCreated,
         PlanStatusUpdated: PlanStatusUpdated,
         Subscribed: Subscribed,
-        Unsubscribed: Unsubscribed,
         SubscriptionRenewed: SubscriptionRenewed,
-        SubscriptionSwitched: SubscriptionSwitched,
     }
 
     #[derive(Drop, starknet::Event)]
@@ -47,10 +52,10 @@ pub mod Subscription {
         #[key]
         pub plan_id: u256,
         #[key]
+        pub creator: ContractAddress,
         pub recipient: ContractAddress,
         pub price: u256,
         pub duration: u64,
-        pub tier: felt252,
         pub payment_token: Option<ContractAddress>,
         pub metadata_uri: ByteArray,
         pub created_at: u64,
@@ -75,15 +80,6 @@ pub mod Subscription {
     }
 
     #[derive(Drop, starknet::Event)]
-    pub struct Unsubscribed {
-        #[key]
-        pub subscriber: ContractAddress,
-        #[key]
-        pub plan_id: u256,
-        pub unsubscribed_at: u64,
-    }
-
-    #[derive(Drop, starknet::Event)]
     pub struct SubscriptionRenewed {
         #[key]
         pub subscriber: ContractAddress,
@@ -93,23 +89,9 @@ pub mod Subscription {
         pub expires_at: u64,
     }
 
-    #[derive(Drop, starknet::Event)]
-    pub struct SubscriptionSwitched {
-        #[key]
-        pub subscriber: ContractAddress,
-        #[key]
-        pub current_plan_id: u256,
-        #[key]
-        pub new_plan_id: u256,
-        pub switched_at: u64,
-        pub expires_at: u64,
-    }
-
     #[constructor]
-    fn constructor(ref self: ContractState, owner: ContractAddress) {
-        assert(!owner.is_zero(), 'Owner is zero address');
+    fn constructor(ref self: ContractState) {
         self.src5.register_interface(IIP_SUBSCRIPTION_ID);
-        self.owner.write(owner);
     }
 
     #[abi(embed_v0)]
@@ -118,15 +100,17 @@ pub mod Subscription {
             ref self: ContractState,
             price: u256,
             duration: u64,
-            tier: felt252,
             payment_token: Option<ContractAddress>,
             recipient: ContractAddress,
             metadata_uri: ByteArray,
         ) -> u256 {
-            assert(get_caller_address() == self.owner.read(), 'Only owner can create plans');
+            let creator = get_caller_address();
+            assert(!creator.is_zero(), 'Creator is zero address');
             assert(duration > 0, 'Duration cannot be zero');
             assert(!recipient.is_zero(), 'Recipient is zero address');
 
+            // Plan metadata must be content-addressed so the record stays
+            // durable and verifiable independently of any gateway.
             let valid_uri = bytearray_starts_with(@metadata_uri, @"ipfs://")
                 || bytearray_starts_with(@metadata_uri, @"ar://");
             assert(valid_uri, 'URI must be ipfs:// or ar://');
@@ -143,12 +127,11 @@ pub mod Subscription {
 
             let plan_id = self.last_plan_id.read() + 1;
             let plan = PlanRecord {
-                id: plan_id,
+                creator,
+                recipient,
                 price,
                 duration,
-                tier,
                 payment_token,
-                recipient,
                 metadata_uri: metadata_uri.clone(),
                 active: true,
                 exists: true,
@@ -161,10 +144,10 @@ pub mod Subscription {
                 .emit(
                     PlanCreated {
                         plan_id,
+                        creator,
                         recipient,
                         price,
                         duration,
-                        tier,
                         payment_token,
                         metadata_uri,
                         created_at: get_block_timestamp(),
@@ -175,10 +158,10 @@ pub mod Subscription {
         }
 
         fn set_plan_active(ref self: ContractState, plan_id: u256, active: bool) {
-            assert(get_caller_address() == self.owner.read(), 'Only owner can update plans');
-
             let mut plan = self.plans.entry(plan_id).read();
             assert(plan.exists, 'Plan does not exist');
+            assert(get_caller_address() == plan.creator, 'Only plan creator');
+
             plan.active = active;
             self.plans.entry(plan_id).write(plan);
 
@@ -198,25 +181,13 @@ pub mod Subscription {
             let existing = self.subscriptions.entry(key).read();
             assert(!is_active(existing, now), 'Already subscribed');
 
-            self.enter_subscription();
-
             let expires_at = now + plan.duration;
-            let record = SubscriptionRecord {
-                subscriber: caller,
-                plan_id,
-                started_at: now,
-                expires_at,
-                active: true,
-                exists: true,
-            };
-            self.subscriptions.entry(key).write(record);
+            self.subscriptions.entry(key).write(SubscriptionRecord { started_at: now, expires_at });
 
-            if !existing.exists {
-                self.subscriber_plan_ids.entry(caller).push(plan_id);
-            }
-
+            // State is final before the external transfer (checks-effects-
+            // interactions); a reentrant call observes consistent storage and
+            // runs under the attacker's own caller context.
             collect_payment(caller, @plan);
-            self.exit_subscription();
 
             self.emit(Subscribed { subscriber: caller, plan_id, started_at: now, expires_at });
         }
@@ -232,95 +203,19 @@ pub mod Subscription {
             let now = get_block_timestamp();
             let key = (caller, plan_id);
             let mut record = self.subscriptions.entry(key).read();
-            assert(record.exists, 'Subscription does not exist');
+            // Renewal extends an active subscription; an expired one restarts
+            // via `subscribe`. The two paths are deliberately disjoint.
+            assert(is_active(record, now), 'Subscription inactive');
 
-            self.enter_subscription();
-
-            let mut base_time = now;
-            if is_active(record, now) {
-                base_time = record.expires_at;
-            }
-
-            record.started_at = now;
-            record.expires_at = base_time + plan.duration;
-            record.active = true;
+            record.expires_at = record.expires_at + plan.duration;
             self.subscriptions.entry(key).write(record);
 
             collect_payment(caller, @plan);
-            self.exit_subscription();
 
             self
                 .emit(
                     SubscriptionRenewed {
                         subscriber: caller, plan_id, renewed_at: now, expires_at: record.expires_at,
-                    },
-                );
-        }
-
-        fn unsubscribe(ref self: ContractState, plan_id: u256) {
-            let caller = get_caller_address();
-            let key = (caller, plan_id);
-            let mut record = self.subscriptions.entry(key).read();
-            assert(record.exists, 'Subscription does not exist');
-            assert(record.active, 'Not currently subscribed');
-
-            let now = get_block_timestamp();
-            record.active = false;
-            record.expires_at = now;
-            self.subscriptions.entry(key).write(record);
-
-            self.emit(Unsubscribed { subscriber: caller, plan_id, unsubscribed_at: now });
-        }
-
-        fn switch_subscription(ref self: ContractState, current_plan_id: u256, new_plan_id: u256) {
-            let caller = get_caller_address();
-            assert(current_plan_id != new_plan_id, 'Plan ids must differ');
-
-            let now = get_block_timestamp();
-            let current_key = (caller, current_plan_id);
-            let mut current_record = self.subscriptions.entry(current_key).read();
-            assert(is_active(current_record, now), 'Current subscription inactive');
-
-            let new_plan = self.plans.entry(new_plan_id).read();
-            assert(new_plan.exists, 'Plan does not exist');
-            assert(new_plan.active, 'Plan is inactive');
-
-            let new_key = (caller, new_plan_id);
-            let existing_new_record = self.subscriptions.entry(new_key).read();
-            assert(!is_active(existing_new_record, now), 'Already subscribed');
-
-            self.enter_subscription();
-
-            current_record.active = false;
-            current_record.expires_at = now;
-            self.subscriptions.entry(current_key).write(current_record);
-
-            let expires_at = now + new_plan.duration;
-            let new_record = SubscriptionRecord {
-                subscriber: caller,
-                plan_id: new_plan_id,
-                started_at: now,
-                expires_at,
-                active: true,
-                exists: true,
-            };
-            self.subscriptions.entry(new_key).write(new_record);
-
-            if !existing_new_record.exists {
-                self.subscriber_plan_ids.entry(caller).push(new_plan_id);
-            }
-
-            collect_payment(caller, @new_plan);
-            self.exit_subscription();
-
-            self
-                .emit(
-                    SubscriptionSwitched {
-                        subscriber: caller,
-                        current_plan_id,
-                        new_plan_id,
-                        switched_at: now,
-                        expires_at,
                     },
                 );
         }
@@ -334,7 +229,7 @@ pub mod Subscription {
             self: @ContractState, subscriber: ContractAddress, plan_id: u256,
         ) -> SubscriptionRecord {
             let record = self.subscriptions.entry((subscriber, plan_id)).read();
-            assert(record.exists, 'Subscription does not exist');
+            assert(record.expires_at != 0, 'Subscription does not exist');
             record
         }
 
@@ -346,32 +241,6 @@ pub mod Subscription {
 
         fn get_last_plan_id(self: @ContractState) -> u256 {
             self.last_plan_id.read()
-        }
-
-        fn get_owner(self: @ContractState) -> ContractAddress {
-            self.owner.read()
-        }
-
-        fn get_user_plan_ids(self: @ContractState, subscriber: ContractAddress) -> Array<u256> {
-            let subscriber_plan_ids = self.subscriber_plan_ids.entry(subscriber);
-            let mut plan_ids: Array<u256> = array![];
-            let len: u64 = subscriber_plan_ids.len();
-            for i in 0..len {
-                plan_ids.append(subscriber_plan_ids.at(i).read());
-            }
-            plan_ids
-        }
-    }
-
-    #[generate_trait]
-    impl InternalImpl of InternalTrait {
-        fn enter_subscription(ref self: ContractState) {
-            assert(!self.subscription_locked.read(), 'Reentrant subscription');
-            self.subscription_locked.write(true);
-        }
-
-        fn exit_subscription(ref self: ContractState) {
-            self.subscription_locked.write(false);
         }
     }
 
@@ -388,6 +257,6 @@ pub mod Subscription {
     }
 
     fn is_active(record: SubscriptionRecord, now: u64) -> bool {
-        record.exists && record.active && record.expires_at >= now
+        record.expires_at != 0 && record.expires_at >= now
     }
 }

--- a/contracts/IP-Subscription/src/interface.cairo
+++ b/contracts/IP-Subscription/src/interface.cairo
@@ -1,8 +1,10 @@
 use starknet::ContractAddress;
 use crate::types::{PlanRecord, SubscriptionRecord};
 
+// Protocol discovery ID registered via SRC5.
+// Derivation: starknet_keccak("mediolano.ip-subscription.v2").
 pub const IIP_SUBSCRIPTION_ID: felt252 =
-    0x02b8b00d09660d14a71dfb5dd9f0acd39174877cf4e400f727b397a385e61ae3;
+    0x013f7d8dc8964bc1dc290304c1f2641165381c97e48c9f1497f90a93f7d513ac;
 
 #[starknet::interface]
 pub trait ISubscription<TContractState> {
@@ -10,7 +12,6 @@ pub trait ISubscription<TContractState> {
         ref self: TContractState,
         price: u256,
         duration: u64,
-        tier: felt252,
         payment_token: Option<ContractAddress>,
         recipient: ContractAddress,
         metadata_uri: ByteArray,
@@ -18,14 +19,10 @@ pub trait ISubscription<TContractState> {
     fn set_plan_active(ref self: TContractState, plan_id: u256, active: bool);
     fn subscribe(ref self: TContractState, plan_id: u256);
     fn renew_subscription(ref self: TContractState, plan_id: u256);
-    fn unsubscribe(ref self: TContractState, plan_id: u256);
-    fn switch_subscription(ref self: TContractState, current_plan_id: u256, new_plan_id: u256);
     fn is_subscribed(self: @TContractState, subscriber: ContractAddress, plan_id: u256) -> bool;
     fn get_subscription(
         self: @TContractState, subscriber: ContractAddress, plan_id: u256,
     ) -> SubscriptionRecord;
     fn get_plan(self: @TContractState, plan_id: u256) -> PlanRecord;
     fn get_last_plan_id(self: @TContractState) -> u256;
-    fn get_owner(self: @TContractState) -> ContractAddress;
-    fn get_user_plan_ids(self: @TContractState, subscriber: ContractAddress) -> Array<u256>;
 }

--- a/contracts/IP-Subscription/src/types.cairo
+++ b/contracts/IP-Subscription/src/types.cairo
@@ -1,5 +1,6 @@
 use starknet::ContractAddress;
 
+// A plan exists iff `creator != 0` (create_plan rejects a zero caller).
 #[derive(Drop, Serde, starknet::Store, Clone)]
 pub struct PlanRecord {
     pub creator: ContractAddress,
@@ -9,7 +10,6 @@ pub struct PlanRecord {
     pub payment_token: Option<ContractAddress>,
     pub metadata_uri: ByteArray,
     pub active: bool,
-    pub exists: bool,
 }
 
 // A subscription exists iff `expires_at != 0`. It is active iff `expires_at >= now`.

--- a/contracts/IP-Subscription/src/types.cairo
+++ b/contracts/IP-Subscription/src/types.cairo
@@ -2,25 +2,22 @@ use starknet::ContractAddress;
 
 #[derive(Drop, Serde, starknet::Store, Clone)]
 pub struct PlanRecord {
-    pub id: u256,
+    pub creator: ContractAddress,
+    pub recipient: ContractAddress,
     pub price: u256,
     pub duration: u64,
-    pub tier: felt252,
     pub payment_token: Option<ContractAddress>,
-    pub recipient: ContractAddress,
     pub metadata_uri: ByteArray,
     pub active: bool,
     pub exists: bool,
 }
 
+// A subscription exists iff `expires_at != 0`. It is active iff `expires_at >= now`.
+// Renewal extends `expires_at`; `started_at` marks the beginning of the current streak.
 #[derive(Copy, Drop, Serde, starknet::Store)]
 pub struct SubscriptionRecord {
-    pub subscriber: ContractAddress,
-    pub plan_id: u256,
     pub started_at: u64,
     pub expires_at: u64,
-    pub active: bool,
-    pub exists: bool,
 }
 
 pub fn bytearray_starts_with(haystack: @ByteArray, needle: @ByteArray) -> bool {

--- a/contracts/IP-Subscription/tests/test_contract.cairo
+++ b/contracts/IP-Subscription/tests/test_contract.cairo
@@ -125,7 +125,7 @@ fn test_create_plan_is_permissionless() {
 
     let plan1 = subscription.get_plan(first);
     assert(plan1.creator == CREATOR1(), 'creator1 should be recorded');
-    assert(plan1.exists && plan1.active, 'plan1 should be live');
+    assert(plan1.active, 'plan1 should be live');
     assert(plan1.price == 0, 'price should be zero');
     assert(plan1.duration == HOUR, 'duration should match');
     assert(plan1.metadata_uri == IPFS_URI(), 'metadata should match');
@@ -183,7 +183,7 @@ fn test_free_plan_rejects_payment_token() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected: 'Paid plan requires token')]
 fn test_paid_plan_requires_payment_token() {
     let subscription = deploy_subscription();
 

--- a/contracts/IP-Subscription/tests/test_contract.cairo
+++ b/contracts/IP-Subscription/tests/test_contract.cairo
@@ -11,8 +11,12 @@ use snforge_std::{
 };
 use starknet::ContractAddress;
 
-fn OWNER() -> ContractAddress {
+fn CREATOR1() -> ContractAddress {
     0x101.try_into().unwrap()
+}
+
+fn CREATOR2() -> ContractAddress {
+    0x105.try_into().unwrap()
 }
 
 fn USER1() -> ContractAddress {
@@ -43,16 +47,16 @@ fn HTTP_URI() -> ByteArray {
     "https://example.com/plan.json"
 }
 
+const HOUR: u64 = 3600;
+
 fn declare_and_deploy(contract_name: ByteArray, calldata: Array<felt252>) -> ContractAddress {
     let contract = declare(contract_name).unwrap().contract_class();
     let (contract_address, _) = contract.deploy(@calldata).unwrap();
     contract_address
 }
 
-fn deploy_subscription(owner: ContractAddress) -> ISubscriptionDispatcher {
-    let mut calldata = array![];
-    calldata.append_serde(owner);
-    let address = declare_and_deploy("Subscription", calldata);
+fn deploy_subscription() -> ISubscriptionDispatcher {
+    let address = declare_and_deploy("Subscription", array![]);
     ISubscriptionDispatcher { contract_address: address }
 }
 
@@ -79,291 +83,142 @@ fn deploy_reentrant_payment_token(subscription: ContractAddress, plan_id: u256) 
     declare_and_deploy("ReentrantPaymentToken", calldata)
 }
 
-fn create_free_plan(subscription: ISubscriptionDispatcher) -> u256 {
-    cheat_caller_address(subscription.contract_address, OWNER(), CheatSpan::TargetCalls(1));
-    subscription.create_plan(0, 3600, 1, Option::None, RECIPIENT(), IPFS_URI())
+fn create_free_plan(subscription: ISubscriptionDispatcher, creator: ContractAddress) -> u256 {
+    cheat_caller_address(subscription.contract_address, creator, CheatSpan::TargetCalls(1));
+    subscription.create_plan(0, HOUR, Option::None, RECIPIENT(), IPFS_URI())
 }
 
+fn create_paid_plan(
+    subscription: ISubscriptionDispatcher,
+    creator: ContractAddress,
+    token: ContractAddress,
+    price: u256,
+) -> u256 {
+    cheat_caller_address(subscription.contract_address, creator, CheatSpan::TargetCalls(1));
+    subscription.create_plan(price, HOUR, Option::Some(token), RECIPIENT(), IPFS_URI())
+}
+
+fn fund_and_approve(
+    token: IERC20Dispatcher, user: ContractAddress, spender: ContractAddress, amount: u256,
+) {
+    mint_erc20(token.contract_address, user, amount);
+    cheat_caller_address(token.contract_address, user, CheatSpan::TargetCalls(1));
+    token.approve(spender, amount);
+}
+
+fn at(subscription: ISubscriptionDispatcher, ts: u64) {
+    cheat_block_timestamp(subscription.contract_address, ts, CheatSpan::TargetCalls(1));
+}
+
+// --- plan creation ---
+
 #[test]
-fn test_create_free_plan() {
-    let subscription = deploy_subscription(OWNER());
+fn test_create_plan_is_permissionless() {
+    let subscription = deploy_subscription();
 
-    let plan_id = create_free_plan(subscription);
+    let first = create_free_plan(subscription, CREATOR1());
+    let second = create_free_plan(subscription, CREATOR2());
 
-    assert(subscription.get_owner() == OWNER(), 'owner should match');
-    assert(plan_id == 1, 'plan id should be one');
-    assert(subscription.get_last_plan_id() == 1, 'last plan id should match');
+    assert(first == 1, 'first plan id should be one');
+    assert(second == 2, 'second plan id should be two');
+    assert(subscription.get_last_plan_id() == 2, 'last plan id should match');
 
-    let plan = subscription.get_plan(plan_id);
-    assert(plan.exists, 'plan should exist');
-    assert(plan.active, 'plan should be active');
-    assert(plan.price == 0, 'price should be zero');
-    assert(plan.duration == 3600, 'duration should match');
-    assert(plan.metadata_uri == IPFS_URI(), 'metadata should match');
+    let plan1 = subscription.get_plan(first);
+    assert(plan1.creator == CREATOR1(), 'creator1 should be recorded');
+    assert(plan1.exists && plan1.active, 'plan1 should be live');
+    assert(plan1.price == 0, 'price should be zero');
+    assert(plan1.duration == HOUR, 'duration should match');
+    assert(plan1.metadata_uri == IPFS_URI(), 'metadata should match');
+
+    let plan2 = subscription.get_plan(second);
+    assert(plan2.creator == CREATOR2(), 'creator2 should be recorded');
 }
 
 #[test]
 fn test_create_plan_accepts_ar_uri() {
-    let subscription = deploy_subscription(OWNER());
+    let subscription = deploy_subscription();
 
-    cheat_caller_address(subscription.contract_address, OWNER(), CheatSpan::TargetCalls(1));
-    let plan_id = subscription.create_plan(0, 3600, 1, Option::None, RECIPIENT(), AR_URI());
+    cheat_caller_address(subscription.contract_address, CREATOR1(), CheatSpan::TargetCalls(1));
+    let plan_id = subscription.create_plan(0, HOUR, Option::None, RECIPIENT(), AR_URI());
 
     assert(subscription.get_plan(plan_id).metadata_uri == AR_URI(), 'metadata should match');
 }
 
 #[test]
-#[should_panic]
-fn test_constructor_rejects_zero_owner() {
-    deploy_subscription(ZERO());
-}
+#[should_panic(expected: 'URI must be ipfs:// or ar://')]
+fn test_create_plan_rejects_http_uri() {
+    let subscription = deploy_subscription();
 
-#[test]
-#[should_panic(expected: 'Only owner can create plans')]
-fn test_only_owner_can_create_plan() {
-    let subscription = deploy_subscription(OWNER());
-
-    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
-    subscription.create_plan(0, 3600, 1, Option::None, RECIPIENT(), IPFS_URI());
+    cheat_caller_address(subscription.contract_address, CREATOR1(), CheatSpan::TargetCalls(1));
+    subscription.create_plan(0, HOUR, Option::None, RECIPIENT(), HTTP_URI());
 }
 
 #[test]
 #[should_panic(expected: 'Duration cannot be zero')]
 fn test_create_plan_rejects_zero_duration() {
-    let subscription = deploy_subscription(OWNER());
+    let subscription = deploy_subscription();
 
-    cheat_caller_address(subscription.contract_address, OWNER(), CheatSpan::TargetCalls(1));
-    subscription.create_plan(0, 0, 1, Option::None, RECIPIENT(), IPFS_URI());
+    cheat_caller_address(subscription.contract_address, CREATOR1(), CheatSpan::TargetCalls(1));
+    subscription.create_plan(0, 0, Option::None, RECIPIENT(), IPFS_URI());
 }
 
 #[test]
-#[should_panic(expected: 'URI must be ipfs:// or ar://')]
-fn test_create_plan_rejects_http_uri() {
-    let subscription = deploy_subscription(OWNER());
+#[should_panic(expected: 'Recipient is zero address')]
+fn test_create_plan_rejects_zero_recipient() {
+    let subscription = deploy_subscription();
 
-    cheat_caller_address(subscription.contract_address, OWNER(), CheatSpan::TargetCalls(1));
-    subscription.create_plan(0, 3600, 1, Option::None, RECIPIENT(), HTTP_URI());
+    cheat_caller_address(subscription.contract_address, CREATOR1(), CheatSpan::TargetCalls(1));
+    subscription.create_plan(0, HOUR, Option::None, ZERO(), IPFS_URI());
 }
 
 #[test]
 #[should_panic(expected: 'Free plan cannot use token')]
 fn test_free_plan_rejects_payment_token() {
-    let subscription = deploy_subscription(OWNER());
-    let erc20 = deploy_erc20();
+    let subscription = deploy_subscription();
+    let token = deploy_erc20();
 
-    cheat_caller_address(subscription.contract_address, OWNER(), CheatSpan::TargetCalls(1));
+    cheat_caller_address(subscription.contract_address, CREATOR1(), CheatSpan::TargetCalls(1));
     subscription
-        .create_plan(0, 3600, 1, Option::Some(erc20.contract_address), RECIPIENT(), IPFS_URI());
+        .create_plan(0, HOUR, Option::Some(token.contract_address), RECIPIENT(), IPFS_URI());
 }
 
 #[test]
 #[should_panic]
 fn test_paid_plan_requires_payment_token() {
-    let subscription = deploy_subscription(OWNER());
+    let subscription = deploy_subscription();
 
-    cheat_caller_address(subscription.contract_address, OWNER(), CheatSpan::TargetCalls(1));
-    subscription.create_plan(1000, 3600, 1, Option::None, RECIPIENT(), IPFS_URI());
+    cheat_caller_address(subscription.contract_address, CREATOR1(), CheatSpan::TargetCalls(1));
+    subscription.create_plan(100, HOUR, Option::None, RECIPIENT(), IPFS_URI());
+}
+
+// --- plan management ---
+
+#[test]
+#[should_panic(expected: 'Only plan creator')]
+fn test_only_plan_creator_can_toggle() {
+    let subscription = deploy_subscription();
+    let plan_id = create_free_plan(subscription, CREATOR1());
+
+    cheat_caller_address(subscription.contract_address, CREATOR2(), CheatSpan::TargetCalls(1));
+    subscription.set_plan_active(plan_id, false);
 }
 
 #[test]
-fn test_subscribe_free_plan_records_expiry() {
-    let subscription = deploy_subscription(OWNER());
-    let plan_id = create_free_plan(subscription);
-    let now: u64 = 1000;
+#[should_panic(expected: 'Plan does not exist')]
+fn test_toggle_unknown_plan_reverts() {
+    let subscription = deploy_subscription();
 
-    cheat_block_timestamp(subscription.contract_address, now, CheatSpan::TargetCalls(1));
-    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
-    subscription.subscribe(plan_id);
-
-    let record = subscription.get_subscription(USER1(), plan_id);
-    assert(record.subscriber == USER1(), 'subscriber should match');
-    assert(record.plan_id == plan_id, 'plan should match');
-    assert(record.started_at == now, 'start should match');
-    assert(record.expires_at == now + 3600, 'expiry should match');
-    assert(subscription.is_subscribed(USER1(), plan_id), 'should be subscribed');
-
-    let plan_ids = subscription.get_user_plan_ids(USER1());
-    assert(plan_ids.len() == 1, 'one plan id expected');
-    assert(*plan_ids.at(0) == plan_id, 'plan id should match');
-}
-
-#[test]
-#[should_panic(expected: 'Already subscribed')]
-fn test_cannot_duplicate_active_subscription() {
-    let subscription = deploy_subscription(OWNER());
-    let plan_id = create_free_plan(subscription);
-
-    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
-    subscription.subscribe(plan_id);
-
-    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
-    subscription.subscribe(plan_id);
-}
-
-#[test]
-fn test_subscription_expires_by_time() {
-    let subscription = deploy_subscription(OWNER());
-    let plan_id = create_free_plan(subscription);
-
-    cheat_block_timestamp(subscription.contract_address, 1000, CheatSpan::TargetCalls(1));
-    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
-    subscription.subscribe(plan_id);
-
-    cheat_block_timestamp(subscription.contract_address, 5000, CheatSpan::TargetCalls(1));
-    assert(!subscription.is_subscribed(USER1(), plan_id), 'should expire');
-}
-
-#[test]
-fn test_renew_subscription_extends_active_subscription() {
-    let subscription = deploy_subscription(OWNER());
-    let plan_id = create_free_plan(subscription);
-
-    cheat_block_timestamp(subscription.contract_address, 1000, CheatSpan::TargetCalls(1));
-    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
-    subscription.subscribe(plan_id);
-
-    cheat_block_timestamp(subscription.contract_address, 2000, CheatSpan::TargetCalls(1));
-    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
-    subscription.renew_subscription(plan_id);
-
-    let record = subscription.get_subscription(USER1(), plan_id);
-    assert(record.expires_at == 8200, 'renew extends expiry');
-    assert(subscription.is_subscribed(USER1(), plan_id), 'should still be active');
-}
-
-#[test]
-fn test_renew_expired_subscription_reactivates_from_now() {
-    let subscription = deploy_subscription(OWNER());
-    let plan_id = create_free_plan(subscription);
-
-    cheat_block_timestamp(subscription.contract_address, 1000, CheatSpan::TargetCalls(1));
-    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
-    subscription.subscribe(plan_id);
-
-    cheat_block_timestamp(subscription.contract_address, 5000, CheatSpan::TargetCalls(1));
-    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
-    subscription.renew_subscription(plan_id);
-
-    let record = subscription.get_subscription(USER1(), plan_id);
-    assert(record.expires_at == 8600, 'renewal should start from now');
-    assert(subscription.is_subscribed(USER1(), plan_id), 'should be active');
-}
-
-#[test]
-fn test_unsubscribe_disables_subscription() {
-    let subscription = deploy_subscription(OWNER());
-    let plan_id = create_free_plan(subscription);
-
-    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
-    subscription.subscribe(plan_id);
-
-    cheat_block_timestamp(subscription.contract_address, 1200, CheatSpan::TargetCalls(1));
-    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
-    subscription.unsubscribe(plan_id);
-
-    assert(!subscription.is_subscribed(USER1(), plan_id), 'should not be active');
-    let record = subscription.get_subscription(USER1(), plan_id);
-    assert(record.expires_at == 1200, 'expiry is unsubscribe');
-}
-
-#[test]
-fn test_paid_subscribe_transfers_tokens() {
-    let subscription = deploy_subscription(OWNER());
-    let erc20 = deploy_erc20();
-
-    cheat_caller_address(subscription.contract_address, OWNER(), CheatSpan::TargetCalls(1));
-    let plan_id = subscription
-        .create_plan(1000, 3600, 1, Option::Some(erc20.contract_address), RECIPIENT(), IPFS_URI());
-
-    mint_erc20(erc20.contract_address, USER1(), 3000);
-    cheat_caller_address(erc20.contract_address, USER1(), CheatSpan::TargetCalls(1));
-    erc20.approve(subscription.contract_address, 1000);
-
-    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
-    subscription.subscribe(plan_id);
-
-    assert(erc20.balance_of(RECIPIENT()) == 1000, 'recipient should be paid');
-    assert(erc20.balance_of(USER1()) == 2000, 'payer balance should decrement');
-}
-
-#[test]
-fn test_paid_renew_transfers_tokens() {
-    let subscription = deploy_subscription(OWNER());
-    let erc20 = deploy_erc20();
-
-    cheat_caller_address(subscription.contract_address, OWNER(), CheatSpan::TargetCalls(1));
-    let plan_id = subscription
-        .create_plan(1000, 3600, 1, Option::Some(erc20.contract_address), RECIPIENT(), IPFS_URI());
-
-    mint_erc20(erc20.contract_address, USER1(), 3000);
-    cheat_caller_address(erc20.contract_address, USER1(), CheatSpan::TargetCalls(1));
-    erc20.approve(subscription.contract_address, 3000);
-
-    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
-    subscription.subscribe(plan_id);
-
-    cheat_block_timestamp(subscription.contract_address, 2000, CheatSpan::TargetCalls(1));
-    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
-    subscription.renew_subscription(plan_id);
-
-    assert(erc20.balance_of(RECIPIENT()) == 2000, 'recipient gets renewal');
-    assert(erc20.balance_of(USER1()) == 1000, 'payer pays twice');
-}
-
-#[test]
-fn test_paid_switch_transfers_new_plan_price() {
-    let subscription = deploy_subscription(OWNER());
-    let erc20 = deploy_erc20();
-
-    cheat_caller_address(subscription.contract_address, OWNER(), CheatSpan::TargetCalls(2));
-    let basic_id = subscription.create_plan(0, 3600, 1, Option::None, RECIPIENT(), IPFS_URI());
-    let pro_id = subscription
-        .create_plan(2000, 7200, 2, Option::Some(erc20.contract_address), RECIPIENT(), IPFS_URI());
-
-    mint_erc20(erc20.contract_address, USER1(), 2500);
-    cheat_caller_address(erc20.contract_address, USER1(), CheatSpan::TargetCalls(1));
-    erc20.approve(subscription.contract_address, 2000);
-
-    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
-    subscription.subscribe(basic_id);
-
-    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
-    subscription.switch_subscription(basic_id, pro_id);
-
-    assert(erc20.balance_of(RECIPIENT()) == 2000, 'recipient gets pro');
-    assert(erc20.balance_of(USER1()) == 500, 'payer pays pro');
-}
-
-#[test]
-fn test_switch_subscription() {
-    let subscription = deploy_subscription(OWNER());
-
-    cheat_caller_address(subscription.contract_address, OWNER(), CheatSpan::TargetCalls(2));
-    let basic_id = subscription.create_plan(0, 3600, 1, Option::None, RECIPIENT(), IPFS_URI());
-    let pro_id = subscription.create_plan(0, 7200, 2, Option::None, RECIPIENT(), IPFS_URI());
-
-    cheat_block_timestamp(subscription.contract_address, 1000, CheatSpan::TargetCalls(1));
-    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
-    subscription.subscribe(basic_id);
-
-    cheat_block_timestamp(subscription.contract_address, 1500, CheatSpan::TargetCalls(1));
-    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
-    subscription.switch_subscription(basic_id, pro_id);
-
-    assert(!subscription.is_subscribed(USER1(), basic_id), 'basic should be inactive');
-    assert(subscription.is_subscribed(USER1(), pro_id), 'pro should be active');
-    assert(
-        subscription.get_subscription(USER1(), pro_id).expires_at == 8700, 'expiry should match',
-    );
+    cheat_caller_address(subscription.contract_address, CREATOR1(), CheatSpan::TargetCalls(1));
+    subscription.set_plan_active(42, false);
 }
 
 #[test]
 #[should_panic(expected: 'Plan is inactive')]
-fn test_inactive_plan_rejects_new_subscription() {
-    let subscription = deploy_subscription(OWNER());
-    let plan_id = create_free_plan(subscription);
+fn test_deactivation_blocks_subscribe() {
+    let subscription = deploy_subscription();
+    let plan_id = create_free_plan(subscription, CREATOR1());
 
-    cheat_caller_address(subscription.contract_address, OWNER(), CheatSpan::TargetCalls(1));
+    cheat_caller_address(subscription.contract_address, CREATOR1(), CheatSpan::TargetCalls(1));
     subscription.set_plan_active(plan_id, false);
 
     cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
@@ -371,33 +226,267 @@ fn test_inactive_plan_rejects_new_subscription() {
 }
 
 #[test]
-#[should_panic(expected: 'Reentrant subscription')]
-fn test_reentrant_payment_token_rejected() {
-    let subscription = deploy_subscription(OWNER());
-    let expected_plan_id = 1;
-    let token = deploy_reentrant_payment_token(subscription.contract_address, expected_plan_id);
+#[should_panic(expected: 'Plan is inactive')]
+fn test_deactivation_blocks_renewal() {
+    let subscription = deploy_subscription();
+    let plan_id = create_free_plan(subscription, CREATOR1());
 
-    cheat_caller_address(subscription.contract_address, OWNER(), CheatSpan::TargetCalls(1));
-    let plan_id = subscription
-        .create_plan(1000, 3600, 1, Option::Some(token), RECIPIENT(), IPFS_URI());
-    assert(plan_id == expected_plan_id, 'test expects first plan');
+    at(subscription, 1000);
+    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
+    subscription.subscribe(plan_id);
 
+    cheat_caller_address(subscription.contract_address, CREATOR1(), CheatSpan::TargetCalls(1));
+    subscription.set_plan_active(plan_id, false);
+
+    at(subscription, 2000);
+    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
+    subscription.renew_subscription(plan_id);
+}
+
+#[test]
+fn test_deactivation_preserves_paid_access() {
+    let subscription = deploy_subscription();
+    let plan_id = create_free_plan(subscription, CREATOR1());
+
+    at(subscription, 1000);
+    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
+    subscription.subscribe(plan_id);
+
+    cheat_caller_address(subscription.contract_address, CREATOR1(), CheatSpan::TargetCalls(1));
+    subscription.set_plan_active(plan_id, false);
+
+    at(subscription, 2000);
+    assert(subscription.is_subscribed(USER1(), plan_id), 'paid access should survive');
+}
+
+#[test]
+fn test_reactivation_allows_subscribe() {
+    let subscription = deploy_subscription();
+    let plan_id = create_free_plan(subscription, CREATOR1());
+
+    cheat_caller_address(subscription.contract_address, CREATOR1(), CheatSpan::TargetCalls(1));
+    subscription.set_plan_active(plan_id, false);
+    cheat_caller_address(subscription.contract_address, CREATOR1(), CheatSpan::TargetCalls(1));
+    subscription.set_plan_active(plan_id, true);
+
+    at(subscription, 1000);
+    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
+    subscription.subscribe(plan_id);
+
+    at(subscription, 1000);
+    assert(subscription.is_subscribed(USER1(), plan_id), 'subscribe should work again');
+}
+
+// --- subscribe / expiry ---
+
+#[test]
+fn test_subscribe_records_expiry() {
+    let subscription = deploy_subscription();
+    let plan_id = create_free_plan(subscription, CREATOR1());
+
+    at(subscription, 1000);
+    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
+    subscription.subscribe(plan_id);
+
+    let record = subscription.get_subscription(USER1(), plan_id);
+    assert(record.started_at == 1000, 'started_at should match');
+    assert(record.expires_at == 1000 + HOUR, 'expires_at should match');
+}
+
+#[test]
+#[should_panic(expected: 'Already subscribed')]
+fn test_cannot_duplicate_active_subscription() {
+    let subscription = deploy_subscription();
+    let plan_id = create_free_plan(subscription, CREATOR1());
+
+    at(subscription, 1000);
+    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
+    subscription.subscribe(plan_id);
+
+    at(subscription, 2000);
     cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
     subscription.subscribe(plan_id);
 }
 
 #[test]
-fn test_supports_subscription_interface() {
-    let subscription = deploy_subscription(OWNER());
-    let src5 = ISRC5Dispatcher { contract_address: subscription.contract_address };
+fn test_subscription_expires_by_time() {
+    let subscription = deploy_subscription();
+    let plan_id = create_free_plan(subscription, CREATOR1());
 
-    assert(src5.supports_interface(IIP_SUBSCRIPTION_ID), 'interface should be supported');
+    at(subscription, 1000);
+    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
+    subscription.subscribe(plan_id);
+
+    // Active through the exact expiry second, inactive after it.
+    at(subscription, 1000 + HOUR);
+    assert(subscription.is_subscribed(USER1(), plan_id), 'active at expiry boundary');
+    at(subscription, 1001 + HOUR);
+    assert(!subscription.is_subscribed(USER1(), plan_id), 'inactive after expiry');
+}
+
+#[test]
+fn test_resubscribe_after_expiry() {
+    let subscription = deploy_subscription();
+    let plan_id = create_free_plan(subscription, CREATOR1());
+
+    at(subscription, 1000);
+    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
+    subscription.subscribe(plan_id);
+
+    let restart = 2000 + HOUR;
+    at(subscription, restart);
+    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
+    subscription.subscribe(plan_id);
+
+    let record = subscription.get_subscription(USER1(), plan_id);
+    assert(record.started_at == restart, 'streak should restart');
+    assert(record.expires_at == restart + HOUR, 'expiry should restart');
+}
+
+// --- renewal ---
+
+#[test]
+fn test_renew_extends_from_current_expiry() {
+    let subscription = deploy_subscription();
+    let plan_id = create_free_plan(subscription, CREATOR1());
+
+    at(subscription, 1000);
+    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
+    subscription.subscribe(plan_id);
+
+    at(subscription, 2000);
+    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
+    subscription.renew_subscription(plan_id);
+
+    let record = subscription.get_subscription(USER1(), plan_id);
+    assert(record.started_at == 1000, 'streak start should be kept');
+    assert(record.expires_at == 1000 + 2 * HOUR, 'expiry should stack');
+}
+
+#[test]
+#[should_panic(expected: 'Subscription inactive')]
+fn test_renew_expired_subscription_reverts() {
+    let subscription = deploy_subscription();
+    let plan_id = create_free_plan(subscription, CREATOR1());
+
+    at(subscription, 1000);
+    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
+    subscription.subscribe(plan_id);
+
+    at(subscription, 2000 + HOUR);
+    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
+    subscription.renew_subscription(plan_id);
+}
+
+#[test]
+#[should_panic(expected: 'Subscription inactive')]
+fn test_renew_without_subscription_reverts() {
+    let subscription = deploy_subscription();
+    let plan_id = create_free_plan(subscription, CREATOR1());
+
+    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
+    subscription.renew_subscription(plan_id);
+}
+
+// --- payments ---
+
+#[test]
+fn test_paid_subscribe_transfers_tokens() {
+    let subscription = deploy_subscription();
+    let token = deploy_erc20();
+    let price: u256 = 250;
+    let plan_id = create_paid_plan(subscription, CREATOR1(), token.contract_address, price);
+
+    fund_and_approve(token, USER1(), subscription.contract_address, price);
+
+    at(subscription, 1000);
+    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
+    subscription.subscribe(plan_id);
+
+    assert(token.balance_of(USER1()) == 0, 'subscriber should be charged');
+    assert(token.balance_of(RECIPIENT()) == price, 'recipient should be paid');
+    at(subscription, 1000);
+    assert(subscription.is_subscribed(USER1(), plan_id), 'subscription should be live');
+}
+
+#[test]
+fn test_paid_renew_transfers_tokens() {
+    let subscription = deploy_subscription();
+    let token = deploy_erc20();
+    let price: u256 = 250;
+    let plan_id = create_paid_plan(subscription, CREATOR1(), token.contract_address, price);
+
+    fund_and_approve(token, USER1(), subscription.contract_address, 2 * price);
+
+    at(subscription, 1000);
+    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
+    subscription.subscribe(plan_id);
+
+    at(subscription, 2000);
+    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
+    subscription.renew_subscription(plan_id);
+
+    assert(token.balance_of(RECIPIENT()) == 2 * price, 'recipient paid twice');
+    let record = subscription.get_subscription(USER1(), plan_id);
+    assert(record.expires_at == 1000 + 2 * HOUR, 'expiry should stack');
+}
+
+#[test]
+#[should_panic]
+fn test_paid_subscribe_without_allowance_reverts() {
+    let subscription = deploy_subscription();
+    let token = deploy_erc20();
+    let plan_id = create_paid_plan(subscription, CREATOR1(), token.contract_address, 250);
+
+    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
+    subscription.subscribe(plan_id);
+}
+
+// A malicious payment token that reenters `subscribe` during `transfer_from`
+// runs under its own caller context: it can only create a subscription for
+// itself. The victim's record is written before the external call
+// (checks-effects-interactions), so state stays consistent without a lock.
+#[test]
+fn test_reentrant_payment_token_is_isolated() {
+    let subscription = deploy_subscription();
+    let free_plan = create_free_plan(subscription, CREATOR1());
+    let reentrant_token = deploy_reentrant_payment_token(subscription.contract_address, free_plan);
+
+    let paid_plan = create_paid_plan(subscription, CREATOR1(), reentrant_token, 250);
+
+    at(subscription, 1000);
+    cheat_caller_address(subscription.contract_address, USER1(), CheatSpan::TargetCalls(1));
+    subscription.subscribe(paid_plan);
+
+    at(subscription, 1000);
+    assert(subscription.is_subscribed(USER1(), paid_plan), 'victim sub should be intact');
+    at(subscription, 1000);
+    assert(!subscription.is_subscribed(USER1(), free_plan), 'no sub forged for victim');
+    at(subscription, 1000);
+    let token_address: ContractAddress = reentrant_token;
+    assert(subscription.is_subscribed(token_address, free_plan), 'token only subscribed itself');
+}
+
+// --- views / discovery ---
+
+#[test]
+fn test_supports_subscription_interface() {
+    let subscription = deploy_subscription();
+    let src5 = ISRC5Dispatcher { contract_address: subscription.contract_address };
+    assert(src5.supports_interface(IIP_SUBSCRIPTION_ID), 'SRC5 id should be registered');
 }
 
 #[test]
 #[should_panic(expected: 'Plan does not exist')]
 fn test_missing_plan_reverts() {
-    let subscription = deploy_subscription(OWNER());
+    let subscription = deploy_subscription();
+    subscription.get_plan(42);
+}
 
-    subscription.get_plan(1);
+#[test]
+#[should_panic(expected: 'Subscription does not exist')]
+fn test_missing_subscription_reverts() {
+    let subscription = deploy_subscription();
+    let plan_id = create_free_plan(subscription, CREATOR1());
+    subscription.get_subscription(USER1(), plan_id);
 }


### PR DESCRIPTION
## Why

The 2026-05-23 remediation fixed the legacy prototype's state-machine bugs, but the contract still predated the Mediolano principles. This PR is the one-by-one catalog redesign applied to IP-Subscription: conformance audit first (findings in `AUDIT_REPORT.md`), then a v2 that removes every non-conforming surface.

## What changed

- **No contract owner.** `create_plan` is permissionless; `plan.creator` is recorded per plan and is the only address that can toggle that plan. One shared immutable deployment serves all creators (consistent with IP-Club / IP-Time-Capsule).
- **Paid time is inviolable.** `unsubscribe` and `switch_subscription` are removed — they were the only code paths that could forfeit access a subscriber had paid for (`expires_at = now`). With no on-chain auto-renew, prepaid access has nothing to cancel; switching is a multicall under account abstraction.
- **Deactivation semantics decided + tested:** `set_plan_active(false)` blocks new subscriptions **and** renewals, and never touches existing paid access.
- **Data minimization:** the enumerable `subscriber_plan_ids` roster, the unenforced `tier` field, the redundant reentrancy lock, and record-key duplication are gone. A subscription is `{ started_at, expires_at }`.
- **Disjoint verbs:** `subscribe` starts (requires no active sub), `renew_subscription` extends from current expiry (requires an active sub).
- New SRC5 ID: `starknet_keccak("mediolano.ip-subscription.v2")`.

## Verification

- `scarb fmt` + `scarb build` clean
- `snforge test`: **27 passed, 0 failed** (was 22) — incl. reentrant-token isolation (CEI proof without a lock), expiry boundary, deactivation-preserves-paid-access, paid subscribe/renew balance assertions
- Net diff: −12 lines with 5 more tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)