### PR TITLE
redesign(IP-Tickets): v2 — creator sales switch, ERC-2981 discovery, CEI over lock

### DIFF
--- a/contracts/IP-Tickets/AUDIT_REPORT.md
+++ b/contracts/IP-Tickets/AUDIT_REPORT.md
@@ -1,3 +1,58 @@
+# IP Tickets — v2 Redesign Audit (2026-06-10)
+
+**Date:** 2026-06-10
+**Scope:** Principle-conformance audit of the post-2026-05-23 implementation, followed by the v2 redesign in this tree.
+**Result:** v2 implemented; `scarb build` clean; `snforge test` 26 passed, 0 failed.
+
+## Why a v2
+
+Unlike IP-Subscription, the 2026-05-23 IP-Tickets remediation already satisfied
+the load-bearing Mediolano principles: permissionless series creation, no
+contract owner, zero fees, direct creator payment, standard ERC-721 interop,
+content-addressed metadata. The v2 findings are correspondingly smaller:
+
+| # | Severity | Finding | v2 resolution |
+| --- | --- | --- | --- |
+| T1 | Medium | No way for a creator to stop sales of a series (e.g. a cancelled event) — expiration was the only sunset | `set_series_active(series_id, active)` added: series-creator-only, gates **minting only**. Existing tickets keep access, transferability, and redemption (tested) — mirrors the IP-Subscription v2 deactivation decision |
+| T2 | Medium | `royaltyInfo` was camelCase-only and the ERC-2981 interface ID was not registered in SRC5, so royalty-aware marketplaces could not discover it | `IERC2981_ID` registered in the constructor; snake_case `royalty_info` added alongside the legacy camelCase entry point |
+| T3 | Low | Manual `mint_locked` reentrancy lock was redundant: all series/token state is written before `collect_payment` and `safe_mint` (checks-effects-interactions), and a reentrant call runs under its own caller context | Lock removed; `test_reentrant_payment_token_reverts_atomically` documents the failure mode (the reentrant token can only mint to itself, it is not an ERC-721 receiver, the whole tx reverts, the buyer is never charged) |
+| T4 | Low | `TicketSeries.id` and `.exists` duplicated the map key / derivable state; wasted `redeemed_tickets.write(false)` on every mint | Both fields dropped (existence = `creator != 0`); wasted write removed |
+| T5 | Info | `panic!` ByteArray errors in two branches, inconsistent with felt252 asserts | Replaced with felt252 asserts; `collect_payment` unwraps under the create-time invariant (paid series always carries a non-zero token) |
+| T6 | Info (documented, not changed) | Redeemed/expired tickets remain transferable ERC-721s that no longer grant access — a secondary buyer could overpay for a worthless ticket | Kept by design (standard-interop over lock-in); README now states loudly that integrators must surface `get_ticket_data().valid` on secondary listings |
+| T7 | Info (deferred) | Redemption events publicly link wallet → attendance. Privacy-preserving redemption (ZK entitlement proofs) is a commercial-layer concern, not a substrate concern | Out of scope for the public primitive; tracked in the Medialane privacy-model work |
+
+## v2 invariants
+
+1. **Permissionless**: anyone creates series; anyone mints from an active, unexpired, unsold-out series.
+2. **Ownerless / immutable**: no contract owner, no admin, no upgrade path, no fee. Series terms (price, supply, expiration, royalty, token) never change.
+3. **Sold tickets are inviolable**: nothing the series creator does (including deactivation) affects access, transfer, or redemption of existing tickets.
+4. **CEI**: all storage writes precede the external calls in `mint_ticket`; a reverting payment or receiver check reverts the whole transaction.
+5. **One accounting source**: `active_ticket_balance` is maintained exclusively by the ERC-721 transfer hook and `redeem_ticket`; redeemed tickets are excluded from hook accounting.
+
+## Interface changes (v1 → v2)
+
+- Added: `set_series_active(series_id, active)`, snake_case `royalty_info`, `SeriesStatusUpdated` event, ERC-2981 SRC5 registration.
+- Changed: `TicketSeries` drops `id`/`exists`, gains `active`.
+- New SRC5 ID (interface changed): `0x01362a7858e49627a551fd488764bb296e2e74caaffd1d6a171580904c90c344` = `starknet_keccak("mediolano.ip-tickets.v2")`.
+
+## Verification
+
+```bash
+scarb fmt && scarb build   # clean
+snforge test               # 26 passed, 0 failed
+```
+
+New coverage: creator-only toggle, deactivation blocks mint, deactivation
+preserves access/transfer/redemption, reactivation, snake_case royalty,
+ERC-2981 SRC5 discovery, atomic revert on reentrant payment token.
+
+## Production recommendation
+
+Pre-production until external review and deployment rehearsal. The v1 report
+below is retained for history.
+
+---
+
 # IP Tickets Audit And Remediation Report
 
 **Date:** 2026-05-23

--- a/contracts/IP-Tickets/README.md
+++ b/contracts/IP-Tickets/README.md
@@ -4,6 +4,26 @@
 
 Tickets are indexable and transferable ERC-721 assets. Access follows current ownership until the ticket expires or is redeemed.
 
+## Design (v2, 2026-06-10)
+
+The v2 redesign tightens the contract against the Mediolano principles:
+
+- **Still permissionless and ownerless** (as in v1): anyone creates a series;
+  the contract has no admin, no upgrade path, and takes no fee. Payments flow
+  directly from buyer to the series creator.
+- **Creator sales switch.** `set_series_active(series_id, active)` (series
+  creator only) gates **minting only** — existing tickets keep their access,
+  stay transferable, and stay redeemable. Mirrors IP-Subscription v2: a
+  creator can stop new money (cancelled event), never confiscate sold assets.
+- **CEI instead of a lock.** Series/token state is final before the payment
+  transfer and `safe_mint`; the manual reentrancy lock is removed. A reentrant
+  call runs under its own caller context against consistent storage.
+- **Royalty discovery.** The ERC-2981 interface ID is registered via SRC5 and
+  `royalty_info` is exposed in snake_case alongside the legacy `royaltyInfo`.
+- **Leaner records.** `TicketSeries` drops its redundant `id`/`exists` fields
+  (existence is `creator != 0`); the wasted `redeemed=false` write on mint is
+  gone.
+
 ## Service Asset Declaration
 
 This service follows the shared doctrine in [`docs/SERVICE_ASSET_DOCTRINE.md`](../../docs/SERVICE_ASSET_DOCTRINE.md).
@@ -17,7 +37,7 @@ This service follows the shared doctrine in [`docs/SERVICE_ASSET_DOCTRINE.md`](.
 | `access_semantics` | Current ownership of at least one unredeemed, unexpired ticket in a series |
 | `marketplace_visibility` | Display and list as ERC721 tickets |
 | `metadata_uri_policy` | `ipfs://` or `ar://` |
-| `src5_interface_id` | `IIP_TICKET_SERVICE_ID` |
+| `src5_interface_id` | `IIP_TICKET_SERVICE_ID` (`starknet_keccak("mediolano.ip-tickets.v2")`) + `IERC2981_ID` |
 
 ## Features
 
@@ -46,6 +66,7 @@ fn create_ticket_series(
     metadata_uri: ByteArray,
 ) -> u256;
 
+fn set_series_active(series_id: u256, active: bool); // series creator only
 fn mint_ticket(series_id: u256) -> u256;
 fn redeem_ticket(token_id: u256);
 
@@ -56,6 +77,7 @@ fn get_ticket_series_id(token_id: u256) -> u256;
 fn get_active_ticket_balance(user: ContractAddress, series_id: u256) -> u256;
 fn get_last_series_id() -> u256;
 fn total_supply() -> u256;
+fn royalty_info(token_id: u256, sale_price: u256) -> (ContractAddress, u256);
 fn royaltyInfo(token_id: u256, sale_price: u256) -> (ContractAddress, u256);
 ```
 
@@ -63,7 +85,7 @@ Custom SRC5 interface ID:
 
 ```cairo
 IIP_TICKET_SERVICE_ID =
-0x0064383abff0b2487b1c4acd681d761b39c91cc025a43bf0f7a355641b7c644f
+0x01362a7858e49627a551fd488764bb296e2e74caaffd1d6a171580904c90c344
 ```
 
 ## Access Semantics
@@ -71,12 +93,15 @@ IIP_TICKET_SERVICE_ID =
 A user has valid access when:
 
 ```text
-series.exists
+series.creator != 0
 && get_block_timestamp() < series.expiration
 && active_ticket_balance[(user, series_id)] > 0
 ```
 
-Transfers move active access for unredeemed tickets. Redeemed tickets remain ERC-721 assets but no longer grant access.
+Transfers move active access for unredeemed tickets. **Redeemed or expired
+tickets remain transferable ERC-721 assets but no longer grant access** —
+marketplaces and buyers must check `get_ticket_data(token_id).valid` before
+pricing a secondary sale. Deactivating a series blocks minting only.
 
 ## Development
 

--- a/contracts/IP-Tickets/src/IPTicketService.cairo
+++ b/contracts/IP-Tickets/src/IPTicketService.cairo
@@ -2,6 +2,7 @@
 pub mod IPTicketService {
     use core::num::traits::Zero;
     use openzeppelin_introspection::src5::SRC5Component;
+    use openzeppelin_token::common::erc2981::interface::IERC2981_ID;
     use openzeppelin_token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
     use openzeppelin_token::erc721::ERC721Component;
     use openzeppelin_token::erc721::interface::{IERC721Metadata, IERC721MetadataCamelOnly};
@@ -39,7 +40,6 @@ pub mod IPTicketService {
         token_to_series: Map<u256, u256>,
         active_ticket_balance: Map<(ContractAddress, u256), u256>,
         redeemed_tickets: Map<u256, bool>,
-        mint_locked: bool,
     }
 
     #[event]
@@ -50,8 +50,17 @@ pub mod IPTicketService {
         #[flat]
         SRC5Event: SRC5Component::Event,
         TicketSeriesCreated: TicketSeriesCreated,
+        SeriesStatusUpdated: SeriesStatusUpdated,
         TicketMinted: TicketMinted,
         TicketRedeemed: TicketRedeemed,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    pub struct SeriesStatusUpdated {
+        #[key]
+        pub series_id: u256,
+        pub active: bool,
+        pub updated_at: u64,
     }
 
     #[derive(Drop, starknet::Event)]
@@ -99,6 +108,7 @@ pub mod IPTicketService {
         // Token URI is resolved per ticket from its ticket series.
         self.erc721.initializer(name, symbol, "");
         self.src5.register_interface(IIP_TICKET_SERVICE_ID);
+        self.src5.register_interface(IERC2981_ID);
         self.next_token_id.write(1);
     }
 
@@ -192,16 +202,12 @@ pub mod IPTicketService {
             if price == 0 {
                 assert(payment_token.is_none(), 'Free ticket cannot use token');
             } else {
-                let token = match payment_token {
-                    Option::Some(token) => token,
-                    Option::None => panic!("Paid ticket requires token"),
-                };
-                assert(!token.is_zero(), 'Payment token is zero');
+                assert(payment_token.is_some(), 'Paid ticket requires token');
+                assert(!payment_token.unwrap().is_zero(), 'Payment token is zero');
             }
 
             let series_id = self.last_series_id.read() + 1;
             let series = TicketSeries {
-                id: series_id,
                 creator,
                 price,
                 max_supply,
@@ -210,7 +216,7 @@ pub mod IPTicketService {
                 royalty_bps,
                 payment_token,
                 metadata_uri: metadata_uri.clone(),
-                exists: true,
+                active: true,
             };
 
             self.ticket_series.write(series_id, series);
@@ -234,16 +240,26 @@ pub mod IPTicketService {
             series_id
         }
 
+        fn set_series_active(ref self: ContractState, series_id: u256, active: bool) {
+            let mut series = self.ticket_series.read(series_id);
+            assert(!series.creator.is_zero(), 'Ticket series does not exist');
+            assert(get_caller_address() == series.creator, 'Only series creator');
+
+            series.active = active;
+            self.ticket_series.write(series_id, series);
+
+            self.emit(SeriesStatusUpdated { series_id, active, updated_at: get_block_timestamp() });
+        }
+
         fn mint_ticket(ref self: ContractState, series_id: u256) -> u256 {
             let mut series = self.ticket_series.read(series_id);
-            assert(series.exists, 'Ticket series does not exist');
+            assert(!series.creator.is_zero(), 'Ticket series does not exist');
+            assert(series.active, 'Series is inactive');
             assert(get_block_timestamp() < series.expiration, 'Ticket series expired');
             assert(series.minted < series.max_supply, 'Max supply reached');
 
             let caller = get_caller_address();
             assert(!caller.is_zero(), 'Recipient is zero address');
-
-            self.enter_mint();
 
             series.minted += 1;
             self.ticket_series.write(series_id, series.clone());
@@ -251,13 +267,15 @@ pub mod IPTicketService {
             let token_id = self.next_token_id.read();
             self.next_token_id.write(token_id + 1);
             self.token_to_series.write(token_id, series_id);
-            self.redeemed_tickets.write(token_id, false);
             self.total_supply.write(self.total_supply.read() + 1);
 
+            // State is final before the external calls (checks-effects-
+            // interactions); a reentrant call from the payment token or the
+            // receiver callback runs under its own caller context against
+            // consistent storage.
             collect_payment(caller, @series);
 
             self.erc721.safe_mint(caller, token_id, array![].span());
-            self.exit_mint();
 
             self
                 .emit(
@@ -296,7 +314,7 @@ pub mod IPTicketService {
 
         fn has_valid_ticket(self: @ContractState, user: ContractAddress, series_id: u256) -> bool {
             let series = self.ticket_series.read(series_id);
-            if !series.exists {
+            if series.creator.is_zero() {
                 return false;
             }
             if get_block_timestamp() >= series.expiration {
@@ -307,7 +325,7 @@ pub mod IPTicketService {
 
         fn get_ticket_series(self: @ContractState, series_id: u256) -> TicketSeries {
             let series = self.ticket_series.read(series_id);
-            assert(series.exists, 'Ticket series does not exist');
+            assert(!series.creator.is_zero(), 'Ticket series does not exist');
             series
         }
 
@@ -316,7 +334,9 @@ pub mod IPTicketService {
             let series_id = self.token_to_series.read(token_id);
             let series = self.ticket_series.read(series_id);
             let redeemed = self.redeemed_tickets.read(token_id);
-            let valid = series.exists && !redeemed && get_block_timestamp() < series.expiration;
+            let valid = !series.creator.is_zero()
+                && !redeemed
+                && get_block_timestamp() < series.expiration;
 
             TicketData {
                 token_id,
@@ -349,36 +369,34 @@ pub mod IPTicketService {
             self.total_supply.read()
         }
 
+        fn royalty_info(
+            self: @ContractState, token_id: u256, sale_price: u256,
+        ) -> (ContractAddress, u256) {
+            compute_royalty(self, token_id, sale_price)
+        }
+
         fn royaltyInfo(
             self: @ContractState, token_id: u256, sale_price: u256,
         ) -> (ContractAddress, u256) {
-            self.erc721._require_owned(token_id);
-            let series_id = self.token_to_series.read(token_id);
-            let series = self.ticket_series.read(series_id);
-            let royalty_amount = (sale_price * series.royalty_bps) / 10000;
-            (series.creator, royalty_amount)
+            compute_royalty(self, token_id, sale_price)
         }
     }
 
-    #[generate_trait]
-    impl InternalImpl of InternalTrait {
-        fn enter_mint(ref self: ContractState) {
-            assert(!self.mint_locked.read(), 'Reentrant mint');
-            self.mint_locked.write(true);
-        }
-
-        fn exit_mint(ref self: ContractState) {
-            self.mint_locked.write(false);
-        }
+    fn compute_royalty(
+        self: @ContractState, token_id: u256, sale_price: u256,
+    ) -> (ContractAddress, u256) {
+        self.erc721._require_owned(token_id);
+        let series_id = self.token_to_series.read(token_id);
+        let series = self.ticket_series.read(series_id);
+        let royalty_amount = (sale_price * series.royalty_bps) / 10000;
+        (series.creator, royalty_amount)
     }
 
     fn collect_payment(payer: ContractAddress, series: @TicketSeries) {
         if *series.price > 0 {
-            let payment_token = match *series.payment_token {
-                Option::Some(token) => token,
-                Option::None => panic!("Payment token missing"),
-            };
-            let token = IERC20Dispatcher { contract_address: payment_token };
+            // create_ticket_series guarantees a paid series carries a
+            // non-zero payment token, and series terms are immutable.
+            let token = IERC20Dispatcher { contract_address: (*series.payment_token).unwrap() };
             let result = token.transfer_from(payer, *series.creator, *series.price);
             assert(result, 'Token Transfer Failed');
         }

--- a/contracts/IP-Tickets/src/interface.cairo
+++ b/contracts/IP-Tickets/src/interface.cairo
@@ -1,8 +1,10 @@
 use starknet::ContractAddress;
 use crate::types::{TicketData, TicketSeries};
 
+// Protocol discovery ID registered via SRC5.
+// Derivation: starknet_keccak("mediolano.ip-tickets.v2").
 pub const IIP_TICKET_SERVICE_ID: felt252 =
-    0x0064383abff0b2487b1c4acd681d761b39c91cc025a43bf0f7a355641b7c644f;
+    0x01362a7858e49627a551fd488764bb296e2e74caaffd1d6a171580904c90c344;
 
 #[starknet::interface]
 pub trait IIPTicketService<TContractState> {
@@ -15,6 +17,8 @@ pub trait IIPTicketService<TContractState> {
         payment_token: Option<ContractAddress>,
         metadata_uri: ByteArray,
     ) -> u256;
+
+    fn set_series_active(ref self: TContractState, series_id: u256, active: bool);
 
     fn mint_ticket(ref self: TContractState, series_id: u256) -> u256;
 
@@ -35,6 +39,10 @@ pub trait IIPTicketService<TContractState> {
     fn get_last_series_id(self: @TContractState) -> u256;
 
     fn total_supply(self: @TContractState) -> u256;
+
+    fn royalty_info(
+        self: @TContractState, token_id: u256, sale_price: u256,
+    ) -> (ContractAddress, u256);
 
     fn royaltyInfo(
         self: @TContractState, token_id: u256, sale_price: u256,

--- a/contracts/IP-Tickets/src/types.cairo
+++ b/contracts/IP-Tickets/src/types.cairo
@@ -1,8 +1,9 @@
 use starknet::ContractAddress;
 
+// A series exists iff `creator != 0` (create_ticket_series rejects a zero
+// caller). `active` gates minting only — never transfers or redemption.
 #[derive(Drop, Serde, starknet::Store, Clone)]
 pub struct TicketSeries {
-    pub id: u256,
     pub creator: ContractAddress,
     pub price: u256,
     pub max_supply: u256,
@@ -11,7 +12,7 @@ pub struct TicketSeries {
     pub royalty_bps: u256,
     pub payment_token: Option<ContractAddress>,
     pub metadata_uri: ByteArray,
-    pub exists: bool,
+    pub active: bool,
 }
 
 #[derive(Drop, Serde)]

--- a/contracts/IP-Tickets/tests/test_ipticket_service.cairo
+++ b/contracts/IP-Tickets/tests/test_ipticket_service.cairo
@@ -3,6 +3,7 @@ use ip_ticket::interface::{
 };
 use ip_ticket::mock::mock_erc20::{IERC20MintDispatcher, IERC20MintDispatcherTrait};
 use openzeppelin_introspection::interface::{ISRC5Dispatcher, ISRC5DispatcherTrait};
+use openzeppelin_token::common::erc2981::interface::IERC2981_ID;
 use openzeppelin_token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
 use openzeppelin_token::erc721::interface::{
     IERC721Dispatcher, IERC721DispatcherTrait, IERC721MetadataDispatcher,
@@ -153,7 +154,7 @@ fn test_create_ticket_series_rejects_bad_royalty() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected: 'Paid ticket requires token')]
 fn test_paid_ticket_requires_token() {
     let ticket_service = deploy_ticket_service();
 
@@ -334,9 +335,14 @@ fn test_royalty_info_rejects_missing_token() {
     ticket_service.royaltyInfo(999, 1000);
 }
 
+// Without a lock, a payment token reentering `mint_ticket` runs under its own
+// caller context: the inner mint targets the token contract itself, which is
+// not an ERC-721 receiver, so the whole transaction reverts atomically — the
+// buyer is never charged and no state is corrupted (checks-effects-
+// interactions: storage is consistent at the external call).
 #[test]
-#[should_panic(expected: 'Reentrant mint')]
-fn test_reentrant_payment_token_rejected() {
+#[should_panic]
+fn test_reentrant_payment_token_reverts_atomically() {
     let ticket_service = deploy_ticket_service();
     let expected_series_id = 1;
     let token = deploy_reentrant_payment_token(ticket_service.contract_address, expected_series_id);
@@ -351,9 +357,99 @@ fn test_reentrant_payment_token_rejected() {
 }
 
 #[test]
+#[should_panic(expected: 'Only series creator')]
+fn test_only_series_creator_can_toggle() {
+    let ticket_service = deploy_ticket_service();
+    let series_id = create_free_series(ticket_service, 10_000);
+
+    cheat_caller_address(ticket_service.contract_address, USER1(), CheatSpan::TargetCalls(1));
+    ticket_service.set_series_active(series_id, false);
+}
+
+#[test]
+#[should_panic(expected: 'Ticket series does not exist')]
+fn test_toggle_unknown_series_reverts() {
+    let ticket_service = deploy_ticket_service();
+
+    cheat_caller_address(ticket_service.contract_address, CREATOR(), CheatSpan::TargetCalls(1));
+    ticket_service.set_series_active(42, false);
+}
+
+#[test]
+#[should_panic(expected: 'Series is inactive')]
+fn test_deactivation_blocks_mint() {
+    let ticket_service = deploy_ticket_service();
+    let receiver = deploy_receiver();
+    let series_id = create_free_series(ticket_service, 10_000);
+
+    cheat_caller_address(ticket_service.contract_address, CREATOR(), CheatSpan::TargetCalls(1));
+    ticket_service.set_series_active(series_id, false);
+
+    cheat_caller_address(ticket_service.contract_address, receiver, CheatSpan::TargetCalls(1));
+    ticket_service.mint_ticket(series_id);
+}
+
+#[test]
+fn test_deactivation_preserves_existing_tickets() {
+    let ticket_service = deploy_ticket_service();
+    let receiver_1 = deploy_receiver();
+    let receiver_2 = deploy_receiver();
+    let series_id = create_free_series(ticket_service, 10_000);
+
+    cheat_caller_address(ticket_service.contract_address, receiver_1, CheatSpan::TargetCalls(1));
+    let token_id = ticket_service.mint_ticket(series_id);
+
+    cheat_caller_address(ticket_service.contract_address, CREATOR(), CheatSpan::TargetCalls(1));
+    ticket_service.set_series_active(series_id, false);
+
+    // Access, transfer, and redemption all survive deactivation.
+    assert(ticket_service.has_valid_ticket(receiver_1, series_id), 'access should survive');
+
+    let erc721 = IERC721Dispatcher { contract_address: ticket_service.contract_address };
+    cheat_caller_address(ticket_service.contract_address, receiver_1, CheatSpan::TargetCalls(1));
+    erc721.transfer_from(receiver_1, receiver_2, token_id);
+    assert(ticket_service.has_valid_ticket(receiver_2, series_id), 'transfer should survive');
+
+    cheat_caller_address(ticket_service.contract_address, receiver_2, CheatSpan::TargetCalls(1));
+    ticket_service.redeem_ticket(token_id);
+    assert(ticket_service.get_ticket_data(token_id).redeemed, 'redeem should survive');
+}
+
+#[test]
+fn test_reactivation_allows_mint() {
+    let ticket_service = deploy_ticket_service();
+    let receiver = deploy_receiver();
+    let series_id = create_free_series(ticket_service, 10_000);
+
+    cheat_caller_address(ticket_service.contract_address, CREATOR(), CheatSpan::TargetCalls(1));
+    ticket_service.set_series_active(series_id, false);
+    cheat_caller_address(ticket_service.contract_address, CREATOR(), CheatSpan::TargetCalls(1));
+    ticket_service.set_series_active(series_id, true);
+
+    cheat_caller_address(ticket_service.contract_address, receiver, CheatSpan::TargetCalls(1));
+    ticket_service.mint_ticket(series_id);
+    assert(ticket_service.has_valid_ticket(receiver, series_id), 'mint should work again');
+}
+
+#[test]
+fn test_royalty_info_snake_case() {
+    let ticket_service = deploy_ticket_service();
+    let receiver = deploy_receiver();
+    let series_id = create_free_series(ticket_service, 10_000);
+
+    cheat_caller_address(ticket_service.contract_address, receiver, CheatSpan::TargetCalls(1));
+    let token_id = ticket_service.mint_ticket(series_id);
+
+    let (recipient, amount) = ticket_service.royalty_info(token_id, 1000);
+    assert(recipient == CREATOR(), 'royalty recipient');
+    assert(amount == 50, 'royalty amount');
+}
+
+#[test]
 fn test_supports_ticket_service_interface() {
     let ticket_service = deploy_ticket_service();
     let src5 = ISRC5Dispatcher { contract_address: ticket_service.contract_address };
 
     assert(src5.supports_interface(IIP_TICKET_SERVICE_ID), 'interface supported');
+    assert(src5.supports_interface(IERC2981_ID), 'erc2981 supported');
 }


### PR DESCRIPTION
## Why

Second contract in the one-by-one principle-conformance redesign of the catalog (after IP-Subscription, #137). IP-Tickets was already in good shape — permissionless series creation, no contract owner, zero fees, direct creator payment — so this is a tightening pass, not a rebuild. Findings + rationale in the new top section of `AUDIT_REPORT.md`.

## What changed

- **Creator sales switch (T1).** `set_series_active(series_id, active)` — series-creator-only, gates **minting only**. A creator whose event is cancelled can stop sales; existing tickets keep access, transferability, and redemption (explicitly tested). Mirrors the IP-Subscription v2 deactivation decision: stop new money, never touch sold assets.
- **Royalty discovery (T2).** `IERC2981_ID` registered via SRC5; snake_case `royalty_info` added alongside the legacy `royaltyInfo` so royalty-aware marketplaces can actually find it.
- **CEI over lock (T3).** `mint_locked` removed — all state is written before `collect_payment` and `safe_mint`. The reentrancy test now documents the failure mode: a malicious payment token reentering mint can only mint to itself, isn't an ERC-721 receiver, and the whole tx reverts atomically.
- **Leaner records (T4/T5).** `TicketSeries` drops `id`/`exists` (existence = `creator != 0`); wasted `redeemed=false` write removed; `panic!` branches → felt252 asserts.
- **Documented, unchanged (T6).** Redeemed/expired tickets stay transferable ERC-721s (interop over lock-in); README now tells integrators loudly to surface `get_ticket_data().valid` on secondary listings.
- New SRC5 ID: `starknet_keccak("mediolano.ip-tickets.v2")`.

## Verification

- `scarb fmt` + `scarb build` clean
- `snforge test`: **26 passed, 0 failed** (was 20) — new coverage: toggle auth, deactivation blocks mint, deactivation preserves access/transfer/redemption, reactivation, ERC-2981 SRC5, snake_case royalty, atomic reentrancy revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)