### PR TITLE
chore(repo): contracts CI + redesign conventions doc

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,0 +1,82 @@
+name: contracts
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      dirs: ${{ steps.changed.outputs.dirs }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Only contracts touched by the change are built and tested — the
+      # catalog contains legacy packages that predate the redesign effort
+      # and are not expected to build until their own redesign PR.
+      - id: changed
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="origin/${{ github.base_ref }}"
+          else
+            BASE="${{ github.event.before }}"
+            git cat-file -e "$BASE" 2>/dev/null || BASE="HEAD~1"
+          fi
+          DIRS=$(git diff --name-only "$BASE"...HEAD -- 'contracts/**' \
+            | cut -d/ -f1-2 | sort -u \
+            | while read -r d; do [ -f "$d/Scarb.toml" ] && echo "$d"; done \
+            | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "dirs=${DIRS:-[]}" >> "$GITHUB_OUTPUT"
+          echo "Changed contract dirs: ${DIRS:-[]}"
+
+  build-and-test:
+    needs: detect
+    if: needs.detect.outputs.dirs != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dir: ${{ fromJson(needs.detect.outputs.dirs) }}
+    name: ${{ matrix.dir }}
+    defaults:
+      run:
+        working-directory: ${{ matrix.dir }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # Versions come from the contract's .tool-versions when present;
+      # otherwise the repo-wide baseline (scarb 2.17.0 / snforge 0.59.0).
+      - id: versions
+        shell: bash
+        run: |
+          SCARB="2.17.0"; FOUNDRY="0.59.0"
+          if [ -f .tool-versions ]; then
+            S=$(awk '$1 == "scarb" { print $2 }' .tool-versions)
+            F=$(awk '$1 == "starknet-foundry" { print $2 }' .tool-versions)
+            [ -n "$S" ] && SCARB="$S"
+            [ -n "$F" ] && FOUNDRY="$F"
+          fi
+          echo "scarb=$SCARB" >> "$GITHUB_OUTPUT"
+          echo "foundry=$FOUNDRY" >> "$GITHUB_OUTPUT"
+
+      - uses: software-mansion/setup-scarb@v1
+        with:
+          scarb-version: ${{ steps.versions.outputs.scarb }}
+
+      - uses: foundry-rs/setup-snfoundry@v3
+        with:
+          starknet-foundry-version: ${{ steps.versions.outputs.foundry }}
+
+      - name: Format check
+        run: scarb fmt --check
+
+      - name: Build
+        run: scarb build
+
+      - name: Test
+        run: snforge test

--- a/docs/REDESIGN_CONVENTIONS.md
+++ b/docs/REDESIGN_CONVENTIONS.md
@@ -1,0 +1,118 @@
+# Service Redesign Conventions
+
+**Status:** Working conventions for the one-by-one redesign of the contract
+catalog. Established across the first three redesigns: IP-Subscription (#137),
+IP-Tickets (#138), IP-Time-Capsule (#139).
+
+Most contracts in this repository were written before the Mediolano
+architecture principles existed. Each is being redesigned **one at a time**,
+audit-first, against those principles. This document is the checklist so each
+redesign doesn't re-derive the doctrine — and so review can diff a PR against
+a known standard.
+
+## Process
+
+1. **Audit before redesign.** Read the existing implementation against the
+   principles (`mediolano-core/docs/architecture/01-principles.md`). Record
+   findings in a severity table at the top of the contract's
+   `AUDIT_REPORT.md` (prepend a dated section; keep prior reports below for
+   history). Every finding gets a resolution — including "documented,
+   unchanged" with the reason.
+2. **One contract per branch/PR.** Branch `redesign/<name>-v2` from `main`.
+   Never bundle two contracts; never touch files outside the contract's
+   directory (plus repo-level docs/CI when that is the explicit task).
+3. **Verify before claiming.** `scarb fmt && scarb build && snforge test`
+   green locally; CI re-runs the same for every changed contract directory.
+4. **README carries the design.** Every contract directory must have a
+   `README.md`: what the service is, a Service Asset Declaration table (per
+   `docs/SERVICE_ASSET_DOCTRINE.md`), the interface, rules/semantics, and
+   build/test instructions. Redesigned contracts add a "Design (v2, dated)"
+   section stating what changed and why. Legacy contracts not yet redesigned
+   carry a status line saying so — a README documents what *is*, it does not
+   bless it.
+
+## Contract checklist
+
+### Authority
+- [ ] **No contract owner, no admin, no upgrade path, no pause switch.** One
+      shared immutable deployment serves all creators.
+- [ ] **Creation is permissionless**; the creating caller is recorded on the
+      record (`creator`) and is the only address with management rights over
+      *that record*.
+- [ ] **Management = sales switch only.** An `active` flag may gate *new
+      payments* (subscribe/renew/mint). It must never affect what buyers
+      already paid for: access, transfer, and redemption of existing assets
+      survive deactivation.
+- [ ] **Sold value is inviolable.** No code path — including the creator's —
+      may shorten a paid period, revoke a sold asset, or reduce an
+      `expires_at`/entitlement. If a function's only effect is forfeiting
+      paid value (v1 `unsubscribe`), remove it.
+- [ ] **Economic terms are immutable.** Price, duration, supply, royalty,
+      token, recipient never change after creation; new terms = new record.
+
+### Money
+- [ ] **Zero fee in the contract.** Payments flow payer → record's
+      recipient/creator directly via `transfer_from`; check the bool result.
+- [ ] Free records: `price == 0` ⇔ `payment_token` is `None`. Paid records
+      carry a non-zero token, validated at creation, so settlement may unwrap
+      under that invariant (with a comment naming it).
+
+### Safety
+- [ ] **Checks-effects-interactions, no manual locks.** All storage writes
+      precede every external call (`transfer_from`, `safe_mint`/receiver
+      callbacks). Reentrant calls run under their own caller context against
+      consistent state. Prove it with a test (malicious payment token, or a
+      probing receiver that reads state inside the mint callback).
+- [ ] **felt252 short-string asserts only** — no `panic!` ByteArray errors.
+      Tests pin exact panic strings wherever the revert is deterministic.
+
+### Data minimization
+- [ ] **Derive, don't store.** Existence ⇔ `creator != 0` (creation rejects a
+      zero caller). Revealed/active states derive from timestamps
+      (`revealed_at != 0`, `expires_at >= now`). No `exists`/`status` flags,
+      no record storing its own map key.
+- [ ] **No on-chain enumeration structures** (rosters, per-user ID vectors,
+      ERC721Enumerable). Indexers rebuild views from keyed events; data not
+      held cannot be compelled.
+- [ ] **Events carry history; storage carries the minimum present.** Values
+      with no post-hoc on-chain utility (e.g. a verified commitment salt)
+      live in events only.
+
+### Interop & discovery
+- [ ] Standard token interfaces; metadata URIs must be content-addressed
+      (`ipfs://` or `ar://`).
+- [ ] **SRC5 ID**: `starknet_keccak("mediolano.<service>.v2")`, derivation
+      commented at the constant. New surface ⇒ new ID.
+- [ ] Register every supported standard's interface ID (e.g. `IERC2981_ID`
+      when royalties exist) and expose snake_case entry points (keep existing
+      camelCase twins for compatibility; don't add new ones).
+- [ ] Assets remain transferable by default; service-specific
+      non-transferability must be justified by the service itself. If an
+      asset can outlive its utility (redeemed ticket), say so loudly in the
+      README and expose a validity getter for integrators.
+
+### Boundaries & semantics
+- [ ] Time boundaries are explicit and tested at the exact second (inclusive
+      expiry for subscriptions, exclusive expiration for ticket series — keep
+      each contract internally consistent and documented).
+- [ ] Verbs are disjoint: one function starts, another extends; no function
+      does both depending on hidden state.
+
+### Toolchain
+- [ ] `.tool-versions` pins `scarb` and `starknet-foundry` in the contract
+      directory (CI reads it; baseline scarb 2.17.0 / snforge 0.59.0).
+- [ ] OZ 0.20 empty hooks: `use openzeppelin::token::erc721::ERC721HooksEmptyImpl;`
+      (import the impl — an alias `impl X = ...` fails to satisfy the trait).
+
+## Deliberate non-goals
+
+- **No shared helper package.** Each contract is a standalone Scarb project
+  (independent audit scope, independent deploys). Duplicated 30-line helpers
+  (`bytearray_starts_with`) are cheaper than coupling audit units.
+- **No optimization without measurement.** Correctness redesigns don't carry
+  eyeballed gas changes; storage-layout optimizations need before/after
+  numbers from `snforge` gas reports in the PR.
+- **No privacy cryptography in the substrate.** Commitments and timed reveals
+  are in scope (IP-Time-Capsule); ZK entitlement proofs, viewing keys, and
+  confidential amounts are commercial-layer concerns built *on top of* these
+  primitives, never inside them.


### PR DESCRIPTION
Two one-time investments that compound across the remaining catalog redesigns:

1. **CI** (`.github/workflows/contracts.yml`): every PR now builds, format-checks, and `snforge test`s each contract directory it touches. Only changed directories run — legacy packages that predate the redesign effort aren't expected to build until their own redesign PR. Toolchain versions come from each contract's `.tool-versions` (baseline scarb 2.17.0 / snforge 0.59.0).

2. **`docs/REDESIGN_CONVENTIONS.md`**: the checklist distilled from the first three redesigns (#137 IP-Subscription, #138 IP-Tickets, #139 IP-Time-Capsule) — ownerless/permissionless authority, sold-value-inviolable deactivation, CEI over locks, derive-don't-store data minimization, SRC5 ID derivation, per-contract README requirement, and the deliberate non-goals (no shared helper package, no unmeasured optimization, no privacy crypto in the substrate). Future redesigns get reviewed against this instead of re-deriving the doctrine.

Note: the three open redesign PRs predate this CI, so their checks won't have run — they were verified locally with the same commands the workflow runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)