### PR TITLE
feat: MIP-Collections-ERC721 v0.4.0 — per-token EIP-2981 royalties

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,10 +83,11 @@ Different contracts use different OpenZeppelin and `snforge_std` versions. Check
 
 `snfoundry.toml` in each contract configures `sncast` profiles. Deploy flow: `scarb build` → `sncast --profile <profile> --wait declare` → `sncast --profile <profile> --wait deploy`.
 
-Current `MIP-Collections-ERC721` Starknet mainnet deployment:
-- `IPNft` class hash: `0x02d50b7e6d1a14f17a8fdc2df24d6e493bae6fae579656d81959b8c92de4b13f`
-- `IPCollection` class hash: `0x00203f0e03a472cb6e058327ca22147c75e574cc2876f4981e99bcbcbe716a29`
-- `IPCollection` registry address: `0x07c2207d200a1dce1cc82a117d8ba91dabfe3d1cc5072d9e4cdd9654fbb0ff10`
+Current `MIP-Collections-ERC721` deployment — **chain: Starknet** (v0.4.0, on-chain `version()` == "0.4.0"):
+- `IPNft` class hash: `0x040551f0d009a6d665ddff980a375dfccc71a8928c8bfcc9ab56244bc4464fab`
+- `IPCollection` class hash: `0x063d4ac4ae317fd155216bf1b8a4d3a63172ff72965b9ac48dd5add0c2d32b70`
+- `IPCollection` registry address: `0x0558c9b6ea4d403df6d765fb77be55702c572f0a811f037c6c4209fe1e5aeef2`
+- Adds per-token EIP-2981 royalties (receiver = creator, immutable), `version()` views, `(collection_id, token_id)` token args, `protocol_routed_transfers` stat. Prior immutable deploys remain valid on-chain but are not tracked here.
 
 ## Cairo Coding Conventions
 

--- a/contracts/MIP-Collections-ERC721/README.md
+++ b/contracts/MIP-Collections-ERC721/README.md
@@ -24,17 +24,22 @@ IPCollection (immutable registry)
   ├── create_collection(name, symbol, base_uri)
   │     └── deploy_syscall → IPNft (standalone ERC-721, immutable)
   │                           ├── token_creators: Map<u256, ContractAddress>
-  │                           └── token_registered_at: Map<u256, u64>
-  ├── mint(collection_id, recipient, token_uri) → token_id
-  ├── batch_mint(collection_id, recipients[], token_uris[]) → token_ids[]
+  │                           ├── token_registered_at: Map<u256, u64>
+  │                           └── EIP-2981 royalty per token (receiver = creator, immutable)
+  ├── mint(collection_id, recipient, token_uri, royalty_bps) → token_id
+  ├── batch_mint(collection_id, recipients[], token_uris[], royalty_bps[]) → token_ids[]
   ├── transfer_collection_ownership(collection_id, new_owner)
-  ├── archive(token) / batch_archive(tokens[])
-  └── transfer_token(from, to, token) / batch_transfer(from, to, tokens[])
+  ├── archive(collection_id, token_id) / batch_archive(collection_ids[], token_ids[])
+  └── transfer_token(to, collection_id, token_id) / batch_transfer(from, to, collection_ids[], token_ids[])
 ```
 
 ## Token Identifier Format
 
-Tokens are identified by a `ByteArray` string in the format `"collection_id:token_id"`, e.g. `"3:17"`. This is parsed by `TokenTrait::from_bytes` which validates that exactly one `:` separator is present and both segments are valid decimal numbers.
+Tokens are addressed by two explicit `u256` arguments — `collection_id` and `token_id` — on every
+token operation (`archive`, `transfer_token`, `get_token`, `is_valid_token`,
+`is_transferable_token`) and as parallel `collection_ids` / `token_ids` arrays on the batch calls.
+There is no stringified `"collection_id:token_id"` form (the prior `ByteArray` parser was removed in
+v0.4.0): integrators pass the two numbers directly — cheaper, and no parsing/validation surface.
 
 ## Storage
 
@@ -62,10 +67,10 @@ struct Collection {
 struct CollectionStats {
     total_minted: u256,
     total_archived: u256,
-    total_transfers: u256,       // transfers routed through IPCollection only
+    protocol_routed_transfers: u256,  // transfers routed through IPCollection only
     last_mint_time: u64,
     last_archive_time: u64,
-    last_transfer_time: u64,     // last IPCollection-routed transfer
+    last_transfer_time: u64,          // last IPCollection-routed transfer
 }
 
 struct TokenData {
@@ -90,29 +95,34 @@ fn get_collection_stats(collection_id) -> CollectionStats
 fn is_valid_collection(collection_id) -> bool
 fn is_collection_owner(collection_id, owner) -> bool
 fn list_user_collections(user) -> Span<u256>
+fn version() -> ByteArray            // immutable implementation version, e.g. "0.4.0"
 ```
 
 ### Token operations
 ```cairo
-fn mint(collection_id, recipient, token_uri) -> u256
-fn batch_mint(collection_id, recipients[], token_uris[]) -> Span<u256>
-fn archive(token: ByteArray)              // replaces burn — record preserved
-fn batch_archive(tokens: Array<ByteArray>)
-fn transfer_token(from, to, token)
-fn batch_transfer(from, to, tokens[])
-fn get_token(token: ByteArray) -> TokenData
-fn is_valid_token(token: ByteArray) -> bool
-fn is_transferable_token(token: ByteArray) -> bool
+fn mint(collection_id, recipient, token_uri, royalty_bps: u128) -> u256
+fn batch_mint(collection_id, recipients[], token_uris[], royalty_bps: Array<u128>) -> Span<u256>
+fn archive(collection_id, token_id)              // replaces burn — record preserved
+fn batch_archive(collection_ids[], token_ids[])
+fn transfer_token(to, collection_id, token_id)
+fn batch_transfer(from, to, collection_ids[], token_ids[])
+fn get_token(collection_id, token_id) -> TokenData
+fn is_valid_token(collection_id, token_id) -> bool
+fn is_transferable_token(collection_id, token_id) -> bool
 fn list_user_tokens_per_collection(collection_id, user) -> Span<u256>
 ```
 
-There are no admin or upgrade entrypoints.
+`royalty_bps` (≤ 10_000) sets the token's immutable EIP-2981 royalty with the creator as receiver.
+The deployed `IPNft` exposes the standard read surface — `royalty_info`, `token_royalty`,
+`default_royalty`, `supports_interface(IERC2981_ID)`, and `version()`.
+
+There are no admin or upgrade entrypoints, and no royalty setter — royalty is fixed at mint.
 
 ## Minting And Provenance
 
 Only the collection owner can mint. The `recipient` receives the ERC-721 token, while the caller is recorded as the immutable `original_creator` / author for the token. This keeps custody and authorship separate: tokens can be minted directly to another wallet without rewriting the legal provenance record.
 
-Each mint writes the token URI, original creator, and registration timestamp exactly once. Later transfers, protocol-routed transfers, and collection ownership transfers do not modify those fields.
+Each mint writes the token URI, original creator, registration timestamp, and EIP-2981 royalty exactly once. The royalty receiver is the immutable `original_creator` (never the mutable collection owner), so secondary-sale royalties can never be redirected by an ownership transfer. Later transfers, protocol-routed transfers, and collection ownership transfers do not modify any of those fields.
 
 ## Events
 
@@ -120,12 +130,12 @@ Each mint writes the token URI, original creator, and registration timestamp exa
 |---|---|
 | `CollectionCreated` | collection_id, owner, name, symbol, base_uri |
 | `CollectionOwnershipTransferred` | collection_id, previous_owner, new_owner, timestamp |
-| `TokenMinted` | collection_id, token_id, owner, metadata_uri |
-| `TokenMintedBatch` | collection_id, token_ids, owners, operator, timestamp |
+| `TokenMinted` | collection_id, token_id, owner, metadata_uri, royalty_bps |
+| `TokenMintedBatch` | collection_id, token_ids, owners, metadata_uris, operator, timestamp |
 | `TokenArchived` | collection_id, token_id, operator, timestamp |
-| `TokenArchivedBatch` | tokens, operator, timestamp |
+| `TokenArchivedBatch` | collection_ids, token_ids, operator, timestamp |
 | `TokenTransferred` | collection_id, token_id, from, to, operator, timestamp |
-| `TokenTransferredBatch` | from, to, tokens, operator, timestamp |
+| `TokenTransferredBatch` | from, to, collection_ids, token_ids, operator, timestamp |
 
 ## Archive vs Burn
 
@@ -141,7 +151,7 @@ Active tokens support standard ERC-721 direct transfers on `IPNft`, preserving m
 
 The `IPCollection.transfer_token` and `batch_transfer` methods are optional protocol-aware transfer paths. They update collection transfer stats and emit protocol transfer events. Before using them, the token owner must approve `IPCollection` either with per-token approval or `set_approval_for_all`. The caller must be the token owner, token-approved address, or an approved operator.
 
-Indexers that need complete transfer history should subscribe to both native `IPNft` ERC-721 `Transfer` events and `IPCollection` protocol transfer events. `CollectionStats.total_transfers` counts only transfers routed through `IPCollection`.
+Indexers that need complete transfer history should subscribe to both native `IPNft` ERC-721 `Transfer` events and `IPCollection` protocol transfer events. `CollectionStats.protocol_routed_transfers` counts only transfers routed through `IPCollection`.
 
 ## Metadata URI Semantics
 
@@ -151,24 +161,29 @@ Frontends, SDKs, and indexers should validate and classify known URI formats off
 
 ## Deployments
 
-### Starknet Mainnet
+Chain is a first-class dimension of the protocol; today's deployment lives on **Starknet**.
+
+### Starknet — v0.4.0
 
 | Component | Class hash | Address |
 |---|---|---|
-| `IPNft` immutable ERC-721 class | `0x02d50b7e6d1a14f17a8fdc2df24d6e493bae6fae579656d81959b8c92de4b13f` | Collection instances are deployed by `IPCollection` |
-| `IPCollection` immutable registry/factory class | `0x00203f0e03a472cb6e058327ca22147c75e574cc2876f4981e99bcbcbe716a29` | `0x07c2207d200a1dce1cc82a117d8ba91dabfe3d1cc5072d9e4cdd9654fbb0ff10` |
+| `IPNft` immutable ERC-721 class | `0x040551f0d009a6d665ddff980a375dfccc71a8928c8bfcc9ab56244bc4464fab` | Collection instances are deployed by `IPCollection` |
+| `IPCollection` immutable registry/factory class | `0x063d4ac4ae317fd155216bf1b8a4d3a63172ff72965b9ac48dd5add0c2d32b70` | `0x0558c9b6ea4d403df6d765fb77be55702c572f0a811f037c6c4209fe1e5aeef2` |
 
-| Action | Transaction | Actual fee |
-|---|---|---|
-| Declare `IPNft` | `0x0602f832d8bf6590780bb592c18e98aae9a0df9ad86245f94a92e1467ddbe2b8` | `24.308705 STRK` |
-| Declare `IPCollection` | `0x04c89525842cf5e9f95e23942017bbd7caac40ab1f193a4603a52799ddf59194` | `29.224179 STRK` |
-| Deploy `IPCollection` | `0x0543d8fe9e00c8981f6dd7d4148ad94cba8b9e6dfed69f1d4583c6034f71435f` | `0.036002 STRK` |
+| Action | Transaction |
+|---|---|
+| Declare `IPNft` | `0x0312d3292713a7d7208de7d0200c5ec456930d0d53a6e6bc97fb1d47c3dba4ba` |
+| Declare `IPCollection` | `0x0569ed2167b826e38c27eb2d5b7cd7a823477a1d14a2ec1c7e21bfe7698c200f` |
+| Deploy `IPCollection` | `0x0383633d4ee0140ac1acebc2a28a90aeeb4734f4cedc5b3ff0291411ec74be78` |
+
+v0.4.0 adds per-token EIP-2981 royalties (receiver = creator, immutable), `version()` views,
+`(collection_id, token_id)` token arguments, and the `protocol_routed_transfers` stat.
 
 Deployment verification:
 
-- The deployed registry class hash is `0x00203f0e03a472cb6e058327ca22147c75e574cc2876f4981e99bcbcbe716a29`.
-- The registry constructor received `0x02d50b7e6d1a14f17a8fdc2df24d6e493bae6fae579656d81959b8c92de4b13f` as its immutable `IPNft` class hash.
-- `get_collection_count()` returns `0` immediately after deployment.
+- The deployed registry class hash is `0x063d4ac4ae317fd155216bf1b8a4d3a63172ff72965b9ac48dd5add0c2d32b70`.
+- The registry constructor received `0x040551f0d009a6d665ddff980a375dfccc71a8928c8bfcc9ab56244bc4464fab` as its immutable `IPNft` class hash.
+- `get_collection_count()` returns `0` and `version()` returns `"0.4.0"` immediately after deployment.
 
 Mainnet declaration/deployment flow:
 

--- a/contracts/MIP-Collections-ERC721/Scarb.lock
+++ b/contracts/MIP-Collections-ERC721/Scarb.lock
@@ -3,7 +3,7 @@ version = 1
 
 [[package]]
 name = "ip_collection_erc_721"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "openzeppelin",
  "snforge_std",

--- a/contracts/MIP-Collections-ERC721/Scarb.toml
+++ b/contracts/MIP-Collections-ERC721/Scarb.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ip_collection_erc_721"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024_07"
 
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html

--- a/contracts/MIP-Collections-ERC721/src/IPCollection.cairo
+++ b/contracts/MIP-Collections-ERC721/src/IPCollection.cairo
@@ -20,8 +20,7 @@ pub mod IPCollection {
     use crate::interfaces::IIPCollection::IIPCollection;
     use crate::interfaces::IIPNFT::{IIPNftDispatcher, IIPNftDispatcherTrait};
     use crate::types::{
-        Collection, CollectionStats, TokenData, TokenTrait, MAX_BASE_URI_LEN, MAX_NAME_LEN,
-        MAX_SYMBOL_LEN,
+        Collection, CollectionStats, MAX_BASE_URI_LEN, MAX_NAME_LEN, MAX_SYMBOL_LEN, TokenData,
     };
 
     // IPCollection is intentionally immutable. It deploys immutable IPNft
@@ -78,6 +77,7 @@ pub mod IPCollection {
         pub token_id: u256,
         pub owner: ContractAddress,
         pub metadata_uri: ByteArray,
+        pub royalty_bps: u128,
     }
 
     #[derive(Drop, starknet::Event)]
@@ -86,6 +86,9 @@ pub mod IPCollection {
         pub collection_id: u256,
         pub token_ids: Span<u256>,
         pub owners: Array<ContractAddress>,
+        // D-2: per-token URIs included so event-only/indexer-independent readers can
+        // reconstruct batch-minted metadata without per-token `token_uri` reads.
+        pub metadata_uris: Array<ByteArray>,
         pub operator: ContractAddress,
         pub timestamp: u64,
     }
@@ -102,7 +105,8 @@ pub mod IPCollection {
 
     #[derive(Drop, starknet::Event)]
     pub struct TokenArchivedBatch {
-        pub tokens: Array<ByteArray>,
+        pub collection_ids: Span<u256>,
+        pub token_ids: Span<u256>,
         pub operator: ContractAddress,
         pub timestamp: u64,
     }
@@ -123,7 +127,8 @@ pub mod IPCollection {
     pub struct TokenTransferredBatch {
         pub from: ContractAddress,
         pub to: ContractAddress,
-        pub tokens: Array<ByteArray>,
+        pub collection_ids: Span<u256>,
+        pub token_ids: Span<u256>,
         pub operator: ContractAddress,
         pub timestamp: u64,
     }
@@ -185,13 +190,15 @@ pub mod IPCollection {
         }
 
         /// Mints a new token in the specified collection to the recipient address.
-        /// Only the collection owner can mint.
-        /// Token IDs start at 1 (R-05).
+        /// Only the collection owner can mint. Token IDs start at 1 (R-05).
+        /// `royalty_bps` sets the token's immutable EIP-2981 secondary-sale royalty
+        /// (receiver = the minting collection owner, recorded as the token creator).
         fn mint(
             ref self: ContractState,
             collection_id: u256,
             recipient: ContractAddress,
             token_uri: ByteArray,
+            royalty_bps: u128,
         ) -> u256 {
             assert(!recipient.is_zero(), 'Recipient is zero address');
 
@@ -205,14 +212,16 @@ pub mod IPCollection {
             // R-05: token IDs start at 1 — total_minted + 1 gives the next ID
             let next_token_id = collection_stats.total_minted + 1;
 
-            let ip_nft = IIPNftDispatcher { contract_address: collection.ip_nft };
-            ip_nft.mint(recipient, next_token_id, token_uri.clone(), operator);
-
+            // D-1 (CEI): advance + persist stats BEFORE the external mint call. A revert in
+            // ip_nft.mint rolls this back; doing it first removes any reentrancy ID-collision
+            // surface regardless of future mint internals.
             collection_stats.total_minted = next_token_id;
             collection_stats.last_mint_time = get_block_timestamp();
             self.collection_stats.entry(collection_id).write(collection_stats);
 
-            // R-01: use local token_uri directly — no extra cross-contract call needed
+            let ip_nft = IIPNftDispatcher { contract_address: collection.ip_nft };
+            ip_nft.mint(recipient, next_token_id, token_uri.clone(), operator, royalty_bps);
+
             self
                 .emit(
                     TokenMinted {
@@ -220,6 +229,7 @@ pub mod IPCollection {
                         token_id: next_token_id,
                         owner: recipient,
                         metadata_uri: token_uri,
+                        royalty_bps,
                     },
                 );
 
@@ -227,18 +237,21 @@ pub mod IPCollection {
         }
 
         /// Batch mints tokens in the specified collection to multiple recipients.
-        /// Only the collection owner can batch mint.
+        /// Only the collection owner can batch mint. `recipients`, `token_uris`, and
+        /// `royalty_bps` must all be the same length (per-token royalty).
         fn batch_mint(
             ref self: ContractState,
             collection_id: u256,
             recipients: Array<ContractAddress>,
             token_uris: Array<ByteArray>,
+            royalty_bps: Array<u128>,
         ) -> Span<u256> {
             let n = recipients.len();
             assert(n > 0, 'Recipients array is empty');
 
-            // M-01: arrays must be the same length
+            // M-01: all input arrays must be the same length
             assert(token_uris.len() == n, 'Array lengths mismatch');
+            assert(royalty_bps.len() == n, 'Array lengths mismatch');
 
             let collection = self.collections.read(collection_id);
             assert(!collection.ip_nft.is_zero(), 'Invalid collection');
@@ -247,6 +260,14 @@ pub mod IPCollection {
             assert(operator == collection.owner, 'Only collection owner can mint');
 
             let mut collection_stats = self.collection_stats.read(collection_id);
+            let base = collection_stats.total_minted;
+            let timestamp = get_block_timestamp();
+
+            // D-1 (CEI): advance + persist stats BEFORE any external mint call.
+            collection_stats.total_minted = base + n.into();
+            collection_stats.last_mint_time = timestamp;
+            self.collection_stats.entry(collection_id).write(collection_stats);
+
             let ip_nft = IIPNftDispatcher { contract_address: collection.ip_nft };
 
             let mut i: u32 = 0;
@@ -258,23 +279,19 @@ pub mod IPCollection {
                 assert(!recipient.is_zero(), 'Recipient is zero address');
 
                 // R-05: token IDs start at 1
-                let next_token_id = collection_stats.total_minted + i.into() + 1;
-                ip_nft.mint(recipient, next_token_id, token_uri, operator);
+                let next_token_id = base + i.into() + 1;
+                ip_nft.mint(recipient, next_token_id, token_uri, operator, *royalty_bps.at(i));
                 token_ids.append(next_token_id);
                 i += 1;
-            };
-
-            let timestamp = get_block_timestamp();
-            collection_stats.total_minted += n.into();
-            collection_stats.last_mint_time = timestamp;
-            self.collection_stats.entry(collection_id).write(collection_stats);
+            }
 
             self
                 .emit(
                     TokenMintedBatch {
                         collection_id,
                         token_ids: token_ids.span(),
-                        owners: recipients.clone(),
+                        owners: recipients,
+                        metadata_uris: token_uris,
                         operator,
                         timestamp,
                     },
@@ -303,7 +320,10 @@ pub mod IPCollection {
             let last_index = old_count - 1;
 
             if old_index != last_index {
-                let moved_collection_id = self.user_collections.entry((old_owner, last_index)).read();
+                let moved_collection_id = self
+                    .user_collections
+                    .entry((old_owner, last_index))
+                    .read();
                 self.user_collections.entry((old_owner, old_index)).write(moved_collection_id);
                 self.collection_owner_index.entry(moved_collection_id).write(old_index);
             }
@@ -333,111 +353,109 @@ pub mod IPCollection {
         /// Archives a token, permanently preserving the on-chain provenance record.
         /// Only the token owner can archive their token.
         /// Replaces destructive burn — the IP registration record is never destroyed.
-        fn archive(ref self: ContractState, token: ByteArray) {
-            let token = TokenTrait::from_bytes(token);
-            let collection = self.collections.read(token.collection_id);
+        fn archive(ref self: ContractState, collection_id: u256, token_id: u256) {
+            let collection = self.collections.read(collection_id);
             assert(!collection.ip_nft.is_zero(), 'Invalid collection');
 
             let caller = get_caller_address();
             let token_owner = IERC721Dispatcher { contract_address: collection.ip_nft }
-                .owner_of(token.token_id);
+                .owner_of(token_id);
             assert(token_owner == caller, 'Caller not token owner');
 
-            IIPNftDispatcher { contract_address: collection.ip_nft }.archive(token.token_id);
+            IIPNftDispatcher { contract_address: collection.ip_nft }.archive(token_id);
 
             let timestamp = get_block_timestamp();
-            let mut collection_stats = self.collection_stats.read(token.collection_id);
+            let mut collection_stats = self.collection_stats.read(collection_id);
             collection_stats.total_archived += 1;
             collection_stats.last_archive_time = timestamp;
-            self.collection_stats.entry(token.collection_id).write(collection_stats);
+            self.collection_stats.entry(collection_id).write(collection_stats);
 
-            self
-                .emit(
-                    TokenArchived {
-                        collection_id: token.collection_id,
-                        token_id: token.token_id,
-                        operator: caller,
-                        timestamp,
-                    },
-                );
+            self.emit(TokenArchived { collection_id, token_id, operator: caller, timestamp });
         }
 
-        /// Batch archives multiple tokens.
-        /// C-01 FIX: ownership verified for every token inside the loop.
+        /// Batch archives multiple tokens (parallel `collection_ids` / `token_ids`).
+        /// C-01: ownership verified for every token inside the loop.
         /// Stats are written once per unique collection, not once per token.
-        fn batch_archive(ref self: ContractState, tokens: Array<ByteArray>) {
-            let n = tokens.len();
+        fn batch_archive(
+            ref self: ContractState, collection_ids: Array<u256>, token_ids: Array<u256>,
+        ) {
+            let n = collection_ids.len();
             assert(n > 0, 'Tokens array is empty');
+            assert(token_ids.len() == n, 'Array lengths mismatch');
 
             let caller = get_caller_address();
             let timestamp = get_block_timestamp();
 
             // Accumulate archive counts per collection_id to minimise storage writes.
-            // Key: collection_id.low (felt252); Value: count of archived tokens.
-            // collection_ids are sequential u256 with high=0, so .low is unique.
+            // Key: collection_id.low (felt252); collection_ids are sequential u256 with high=0.
             let mut unique_cols: Array<u256> = array![];
             let mut col_counts: Felt252Dict<u128> = Default::default();
 
             let mut i: u32 = 0;
             while i < n {
-                let token = TokenTrait::from_bytes(tokens.at(i).clone());
-                assert(token.collection_id.high == 0, 'Collection ID too large');
-                let collection = self.collections.read(token.collection_id);
+                let collection_id = *collection_ids.at(i);
+                let token_id = *token_ids.at(i);
+                assert(collection_id.high == 0, 'Collection ID too large');
+                let collection = self.collections.read(collection_id);
                 assert(!collection.ip_nft.is_zero(), 'Invalid collection');
 
-                // C-01 FIX: verify ownership for every token
+                // C-01: verify ownership for every token
                 let token_owner = IERC721Dispatcher { contract_address: collection.ip_nft }
-                    .owner_of(token.token_id);
+                    .owner_of(token_id);
                 assert(token_owner == caller, 'Caller not token owner');
 
-                IIPNftDispatcher { contract_address: collection.ip_nft }.archive(token.token_id);
+                IIPNftDispatcher { contract_address: collection.ip_nft }.archive(token_id);
 
-                let key: felt252 = token.collection_id.low.into();
+                let key: felt252 = collection_id.low.into();
                 let prev = col_counts.get(key);
                 if prev == 0 {
-                    unique_cols.append(token.collection_id);
+                    unique_cols.append(collection_id);
                 }
                 col_counts.insert(key, prev + 1);
 
                 i += 1;
-            };
+            }
 
             // One storage read+write per unique collection rather than per token
             let mut j: u32 = 0;
             while j < unique_cols.len() {
                 let col_id = *unique_cols.at(j);
-                assert(col_id.high == 0, 'Collection ID too large');
                 let count: u256 = col_counts.get(col_id.low.into()).into();
                 let mut stats = self.collection_stats.read(col_id);
                 stats.total_archived += count;
                 stats.last_archive_time = timestamp;
                 self.collection_stats.entry(col_id).write(stats);
                 j += 1;
-            };
+            }
 
             self
                 .emit(
-                    TokenArchivedBatch { tokens: tokens.clone(), operator: caller, timestamp },
+                    TokenArchivedBatch {
+                        collection_ids: collection_ids.span(),
+                        token_ids: token_ids.span(),
+                        operator: caller,
+                        timestamp,
+                    },
                 );
         }
 
-        /// Transfers a token from one address to another.
+        /// Transfers a token from its current owner to `to`.
         /// The IPCollection contract must be approved for the token.
-        /// M-02 FIX: caller must be the token owner or an approved operator.
+        /// O-3: `from` is derived from on-chain ownership (was a redundant argument).
+        /// M-02: caller must be the token owner or an approved operator.
         fn transfer_token(
-            ref self: ContractState, from: ContractAddress, to: ContractAddress, token: ByteArray,
+            ref self: ContractState, to: ContractAddress, collection_id: u256, token_id: u256,
         ) {
-            let token = TokenTrait::from_bytes(token);
-            let collection = self.collections.read(token.collection_id);
+            let collection = self.collections.read(collection_id);
             assert(!collection.ip_nft.is_zero(), 'Invalid collection');
 
             let caller = get_caller_address();
             let ip_nft = IERC721Dispatcher { contract_address: collection.ip_nft };
 
-            // M-02 FIX: caller must be owner or approved operator
-            let token_owner = ip_nft.owner_of(token.token_id);
-            let approved = ip_nft.get_approved(token.token_id);
+            let token_owner = ip_nft.owner_of(token_id);
+            let approved = ip_nft.get_approved(token_id);
             let registry = get_contract_address();
+            // M-02: registry must be approved, and caller must be owner or approved operator
             assert(
                 approved == registry || ip_nft.is_approved_for_all(token_owner, registry),
                 'Contract not approved',
@@ -449,42 +467,41 @@ pub mod IPCollection {
                 'Not authorized',
             );
 
-            ip_nft.transfer_from(from, to, token.token_id);
+            ip_nft.transfer_from(token_owner, to, token_id);
 
-            // R-03 FIX: update transfer stats (was never updated before)
+            // R-03: update protocol-routed transfer stats
             let timestamp = get_block_timestamp();
-            let mut collection_stats = self.collection_stats.read(token.collection_id);
-            collection_stats.total_transfers += 1;
+            let mut collection_stats = self.collection_stats.read(collection_id);
+            collection_stats.protocol_routed_transfers += 1;
             collection_stats.last_transfer_time = timestamp;
-            self.collection_stats.entry(token.collection_id).write(collection_stats);
+            self.collection_stats.entry(collection_id).write(collection_stats);
 
             self
                 .emit(
                     TokenTransferred {
-                        collection_id: token.collection_id,
-                        token_id: token.token_id,
-                        from,
-                        to,
-                        operator: caller,
-                        timestamp,
+                        collection_id, token_id, from: token_owner, to, operator: caller, timestamp,
                     },
                 );
         }
 
-        /// Batch transfers multiple tokens from one address to another.
-        /// H-01 FIX: approval check and caller authorization added inside the loop.
+        /// Batch transfers multiple tokens (parallel `collection_ids` / `token_ids`) from `from`.
+        /// H-01: approval check and caller authorization enforced for every token.
         /// Stats are written once per unique collection, not once per token.
         fn batch_transfer(
             ref self: ContractState,
             from: ContractAddress,
             to: ContractAddress,
-            tokens: Array<ByteArray>,
+            collection_ids: Array<u256>,
+            token_ids: Array<u256>,
         ) {
-            let n = tokens.len();
+            let n = collection_ids.len();
             assert(n > 0, 'Tokens array is empty');
+            assert(token_ids.len() == n, 'Array lengths mismatch');
 
             let caller = get_caller_address();
             let timestamp = get_block_timestamp();
+            // O-2: registry is invariant — read once, not per iteration.
+            let registry = get_contract_address();
 
             // Accumulate transfer counts per collection_id to minimise storage writes
             let mut unique_cols: Array<u256> = array![];
@@ -492,24 +509,23 @@ pub mod IPCollection {
 
             let mut i: u32 = 0;
             while i < n {
-                let token = TokenTrait::from_bytes(tokens.at(i).clone());
-                assert(token.collection_id.high == 0, 'Collection ID too large');
-                let collection = self.collections.read(token.collection_id);
+                let collection_id = *collection_ids.at(i);
+                let token_id = *token_ids.at(i);
+                assert(collection_id.high == 0, 'Collection ID too large');
+                let collection = self.collections.read(collection_id);
                 assert(!collection.ip_nft.is_zero(), 'Invalid collection');
 
                 let ip_nft = IERC721Dispatcher { contract_address: collection.ip_nft };
 
-                let token_owner = ip_nft.owner_of(token.token_id);
-                let approved = ip_nft.get_approved(token.token_id);
-                let registry = get_contract_address();
+                let token_owner = ip_nft.owner_of(token_id);
+                let approved = ip_nft.get_approved(token_id);
 
-                // H-01 FIX: require contract approval (was missing in batch path)
+                // H-01: require contract approval
                 assert(
                     approved == registry || ip_nft.is_approved_for_all(token_owner, registry),
                     'Contract not approved',
                 );
-
-                // H-01 FIX: require caller is authorized (was missing entirely)
+                // H-01: require caller is authorized
                 assert(
                     caller == token_owner
                         || approved == caller
@@ -517,35 +533,39 @@ pub mod IPCollection {
                     'Not authorized',
                 );
 
-                ip_nft.transfer_from(from, to, token.token_id);
+                ip_nft.transfer_from(from, to, token_id);
 
-                let key: felt252 = token.collection_id.low.into();
+                let key: felt252 = collection_id.low.into();
                 let prev = col_counts.get(key);
                 if prev == 0 {
-                    unique_cols.append(token.collection_id);
+                    unique_cols.append(collection_id);
                 }
                 col_counts.insert(key, prev + 1);
 
                 i += 1;
-            };
+            }
 
             // One storage read+write per unique collection rather than per token
             let mut j: u32 = 0;
             while j < unique_cols.len() {
                 let col_id = *unique_cols.at(j);
-                assert(col_id.high == 0, 'Collection ID too large');
                 let count: u256 = col_counts.get(col_id.low.into()).into();
                 let mut stats = self.collection_stats.read(col_id);
-                stats.total_transfers += count;
+                stats.protocol_routed_transfers += count;
                 stats.last_transfer_time = timestamp;
                 self.collection_stats.entry(col_id).write(stats);
                 j += 1;
-            };
+            }
 
             self
                 .emit(
                     TokenTransferredBatch {
-                        from, to, tokens: tokens.clone(), operator: caller, timestamp,
+                        from,
+                        to,
+                        collection_ids: collection_ids.span(),
+                        token_ids: token_ids.span(),
+                        operator: caller,
+                        timestamp,
                     },
                 );
         }
@@ -571,7 +591,7 @@ pub mod IPCollection {
                 let collection_id = self.user_collections.entry((user, i)).read();
                 collections.append(collection_id);
                 i += 1;
-            };
+            }
             collections.span()
         }
 
@@ -583,6 +603,11 @@ pub mod IPCollection {
         /// Returns the total number of collections ever created.
         fn get_collection_count(self: @ContractState) -> u256 {
             self.collection_count.read()
+        }
+
+        /// Returns the immutable implementation version for this deployed registry class.
+        fn version(self: @ContractState) -> ByteArray {
+            "0.4.0"
         }
 
         /// Retrieves statistics for a specific collection.
@@ -598,49 +623,39 @@ pub mod IPCollection {
 
         /// Retrieves full token data including the immutable legal record fields.
         /// Reverts if the collection is invalid or the token does not exist.
-        /// Uses a single cross-contract call (get_full_token_data) instead of four.
-        fn get_token(self: @ContractState, token: ByteArray) -> TokenData {
-            let token = TokenTrait::from_bytes(token);
-            let collection = self.collections.read(token.collection_id);
+        fn get_token(self: @ContractState, collection_id: u256, token_id: u256) -> TokenData {
+            let collection = self.collections.read(collection_id);
             assert(!collection.ip_nft.is_zero(), 'Invalid collection');
 
-            // Single cross-contract call returns all four fields at once
             let nft = IIPNftDispatcher { contract_address: collection.ip_nft };
             let (owner, metadata_uri, original_creator, registered_at) = nft
-                .get_full_token_data(token.token_id);
+                .get_full_token_data(token_id);
 
             TokenData {
-                collection_id: token.collection_id,
-                token_id: token.token_id,
-                owner,
-                metadata_uri,
-                original_creator,
-                registered_at,
+                collection_id, token_id, owner, metadata_uri, original_creator, registered_at,
             }
         }
 
         /// Checks if a token is valid (exists in a valid collection).
         /// Safe: uses token_exists which never panics, unlike owner_of.
-        fn is_valid_token(self: @ContractState, token: ByteArray) -> bool {
-            let token = TokenTrait::from_bytes(token);
-            let collection = self.collections.read(token.collection_id);
+        fn is_valid_token(self: @ContractState, collection_id: u256, token_id: u256) -> bool {
+            let collection = self.collections.read(collection_id);
             if collection.ip_nft.is_zero() {
                 return false;
             }
-            // token_exists reads the owner slot directly and returns false for non-existent
-            // tokens — owner_of would panic, making is_valid_token unusable as a guard
-            IIPNftDispatcher { contract_address: collection.ip_nft }.token_exists(token.token_id)
+            IIPNftDispatcher { contract_address: collection.ip_nft }.token_exists(token_id)
         }
 
         /// Checks if a token exists and has not been archived.
-        fn is_transferable_token(self: @ContractState, token: ByteArray) -> bool {
-            let token = TokenTrait::from_bytes(token);
-            let collection = self.collections.read(token.collection_id);
+        fn is_transferable_token(
+            self: @ContractState, collection_id: u256, token_id: u256,
+        ) -> bool {
+            let collection = self.collections.read(collection_id);
             if collection.ip_nft.is_zero() {
                 return false;
             }
             let nft = IIPNftDispatcher { contract_address: collection.ip_nft };
-            nft.token_exists(token.token_id) && !nft.is_archived(token.token_id)
+            nft.token_exists(token_id) && !nft.is_archived(token_id)
         }
 
         /// Checks if a given address is the owner of a specific collection.

--- a/contracts/MIP-Collections-ERC721/src/IPNft.cairo
+++ b/contracts/MIP-Collections-ERC721/src/IPNft.cairo
@@ -1,6 +1,8 @@
 #[starknet::contract]
 pub mod IPNft {
+    use core::num::traits::Zero;
     use openzeppelin::introspection::src5::SRC5Component;
+    use openzeppelin::token::common::erc2981::{DefaultConfig, ERC2981Component};
     use openzeppelin::token::erc721::ERC721Component;
     use openzeppelin::token::erc721::extensions::ERC721EnumerableComponent;
     use openzeppelin::token::erc721::interface::{IERC721Metadata, IERC721MetadataCamelOnly};
@@ -8,16 +10,18 @@ pub mod IPNft {
         Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
         StoragePointerWriteAccess,
     };
-    use core::num::traits::Zero;
     use starknet::{ContractAddress, get_block_timestamp, get_caller_address};
     use crate::interfaces::IIPNFT::IIPNft;
-    use crate::types::{MAX_BASE_URI_LEN, MAX_NAME_LEN, MAX_SYMBOL_LEN, MAX_TOKEN_URI_LEN};
+    use crate::types::{
+        MAX_BASE_URI_LEN, MAX_NAME_LEN, MAX_ROYALTY_BPS, MAX_SYMBOL_LEN, MAX_TOKEN_URI_LEN,
+    };
 
     component!(path: ERC721Component, storage: erc721, event: ERC721Event);
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
     component!(
         path: ERC721EnumerableComponent, storage: erc721_enumerable, event: ERC721EnumerableEvent,
     );
+    component!(path: ERC2981Component, storage: erc2981, event: ERC2981Event);
 
     // COMP-01: UpgradeableComponent intentionally removed.
     // IPNft contracts are permanently immutable by design — the per-token URI, creator,
@@ -36,10 +40,18 @@ pub mod IPNft {
         ERC721EnumerableComponent::ERC721EnumerableImpl<ContractState>;
     #[abi(embed_v0)]
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
+    // EIP-2981 read surface only: royalty_info + default/token royalty views.
+    // ERC2981AdminOwnableImpl is intentionally NOT embedded — royalty is immutable,
+    // set once per token at mint, with no owner and no post-mint setter.
+    #[abi(embed_v0)]
+    impl ERC2981Impl = ERC2981Component::ERC2981Impl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC2981InfoImpl = ERC2981Component::ERC2981InfoImpl<ContractState>;
 
     impl ERC721InternalImpl = ERC721Component::InternalImpl<ContractState>;
     impl ERC721EnumerableInternalImpl = ERC721EnumerableComponent::InternalImpl<ContractState>;
     impl SRC5ComponentInternalImpl = SRC5Component::InternalImpl<ContractState>;
+    impl ERC2981InternalImpl = ERC2981Component::InternalImpl<ContractState>;
 
     #[storage]
     struct Storage {
@@ -59,6 +71,8 @@ pub mod IPNft {
         src5: SRC5Component::Storage,
         #[substorage(v0)]
         erc721_enumerable: ERC721EnumerableComponent::Storage,
+        #[substorage(v0)]
+        erc2981: ERC2981Component::Storage,
     }
 
     #[event]
@@ -70,6 +84,8 @@ pub mod IPNft {
         SRC5Event: SRC5Component::Event,
         #[flat]
         ERC721EnumerableEvent: ERC721EnumerableComponent::Event,
+        #[flat]
+        ERC2981Event: ERC2981Component::Event,
     }
 
     /// Constructor.
@@ -92,6 +108,11 @@ pub mod IPNft {
 
         self.erc721.initializer(name, symbol, base_uri);
         self.erc721_enumerable.initializer();
+        // EIP-2981: register IERC2981_ID in SRC5. The default royalty is inert
+        // (`registry`, 0%) — it is never used because every token's royalty is set
+        // explicitly at mint via `_set_token_royalty`. A non-zero receiver is required
+        // by the component initializer.
+        self.erc2981.initializer(registry, 0);
         self.collection_id.write(collection_id);
         self.registry.write(registry);
     }
@@ -154,16 +175,23 @@ pub mod IPNft {
             token_id: u256,
             token_uri: ByteArray,
             creator: ContractAddress,
+            royalty_bps: u128,
         ) {
             assert(get_caller_address() == self.registry.read(), 'Only registry');
 
             // R-05: token IDs must be > 0 (IPCollection assigns IDs starting at 1)
             assert(token_id != 0, 'Token ID cannot be zero');
             assert(!creator.is_zero(), 'Creator is zero address');
-            assert(token_uri.len() > 0 && token_uri.len() <= MAX_TOKEN_URI_LEN, 'Invalid URI length');
+            assert(
+                token_uri.len() > 0 && token_uri.len() <= MAX_TOKEN_URI_LEN, 'Invalid URI length',
+            );
+            // EIP-2981 bound — protocol-neutral standard maximum (app caps tighter).
+            assert(royalty_bps <= MAX_ROYALTY_BPS, 'Royalty bps too high');
 
-            // mint intentionally does not call safe_mint; IP records can be minted to any
+            // mint intentionally does NOT call safe_mint; IP records can be minted to any
             // account/contract without requiring an ERC721 receiver callback.
+            // INVARIANT (D-1): this must never become safe_mint — IPCollection relies on the
+            // absence of a receiver callback to keep its `total_minted` accounting reentrancy-free.
             self.erc721.mint(recipient, token_id);
             self.uris.write(token_id, token_uri);
 
@@ -172,6 +200,11 @@ pub mod IPNft {
 
             // COMP-03: store registration timestamp — permanent, never overwritten
             self.token_registered_at.write(token_id, get_block_timestamp());
+
+            // EIP-2981: per-token royalty, receiver = immutable creator, set once at mint.
+            // Never the (mutable) collection owner — a default-to-owner would let royalties
+            // silently redirect on ownership transfer. No setter is exposed, so this is final.
+            self.erc2981._set_token_royalty(token_id, creator, royalty_bps);
         }
 
         /// Archives a token permanently.
@@ -199,6 +232,11 @@ pub mod IPNft {
         /// Returns the address of the immutable registry (IPCollection factory).
         fn get_registry(self: @ContractState) -> ContractAddress {
             self.registry.read()
+        }
+
+        /// Returns the immutable implementation version for this deployed IPNft class.
+        fn version(self: @ContractState) -> ByteArray {
+            "0.4.0"
         }
 
         /// Returns the informational base URI of the collection.

--- a/contracts/MIP-Collections-ERC721/src/interfaces/IIPCollection.cairo
+++ b/contracts/MIP-Collections-ERC721/src/interfaces/IIPCollection.cairo
@@ -5,203 +5,102 @@ use crate::types::{Collection, CollectionStats, TokenData};
 #[starknet::interface]
 pub trait IIPCollection<ContractState> {
     /// Creates a new collection with the given `name`, `symbol`, and `base_uri`.
-    /// Deploys a new IPNft ERC-721 contract for the collection.
-    /// The caller becomes the collection owner.
-    ///
-    /// # Arguments
-    /// * `name` - The name of the collection (must be non-empty).
-    /// * `symbol` - The symbol of the collection (must be non-empty).
-    /// * `base_uri` - The base URI for the collection's metadata.
-    ///
-    /// # Returns
-    /// The unique identifier (`u256`) of the created collection.
+    /// Deploys a new IPNft ERC-721 contract for the collection. The caller becomes the owner.
+    /// Returns the new collection's `u256` id.
     fn create_collection(
         ref self: ContractState, name: ByteArray, symbol: ByteArray, base_uri: ByteArray,
     ) -> u256;
 
-    /// Mints a new token in the specified `collection_id` and assigns it to the `recipient`.
-    /// Only the collection owner can mint.
-    /// Token IDs start at 1. The `token_uri` is stored permanently and must not be empty.
-    ///
-    /// # Arguments
-    /// * `collection_id` - The identifier of the collection to mint in.
-    /// * `recipient` - The address to receive the newly minted token.
-    /// * `token_uri` - The immutable metadata URI/string for the token.
-    ///
-    /// # Returns
-    /// The unique identifier (`u256`) of the minted token.
+    /// Mints a new token in `collection_id` to `recipient`. Only the collection owner can mint.
+    /// Token IDs start at 1. `token_uri` is stored permanently and must not be empty.
+    /// `royalty_bps` sets the token's immutable EIP-2981 royalty (≤ 10_000), receiver = creator.
+    /// Returns the minted token's `u256` id.
     fn mint(
         ref self: ContractState,
         collection_id: u256,
         recipient: ContractAddress,
         token_uri: ByteArray,
+        royalty_bps: u128,
     ) -> u256;
 
-    /// Mints tokens in batch for the specified `collection_id`.
-    /// `recipients` and `token_uris` must be the same length.
-    /// Only the collection owner can batch mint.
-    ///
-    /// # Arguments
-    /// * `collection_id` - The identifier of the collection to mint in.
-    /// * `recipients` - Array of addresses to receive the newly minted tokens.
-    /// * `token_uris` - Array of immutable metadata URI strings for each token.
-    ///
-    /// # Returns
-    /// A Span of token IDs (`u256`) for the minted tokens.
+    /// Batch mints tokens in `collection_id`. `recipients`, `token_uris`, and `royalty_bps`
+    /// must be the same length (per-token royalty). Only the collection owner can batch mint.
+    /// Returns a Span of the minted token IDs.
     fn batch_mint(
         ref self: ContractState,
         collection_id: u256,
         recipients: Array<ContractAddress>,
         token_uris: Array<ByteArray>,
+        royalty_bps: Array<u128>,
     ) -> Span<u256>;
 
-    /// Transfers collection ownership atomically.
-    /// This changes future mint authority only. Existing token legal records are untouched.
-    ///
-    /// # Arguments
-    /// * `collection_id` - The identifier of the collection to transfer.
-    /// * `new_owner` - The address that will become the collection owner.
+    /// Transfers collection ownership atomically (future mint authority only; existing token
+    /// legal records are untouched).
     fn transfer_collection_ownership(
         ref self: ContractState, collection_id: u256, new_owner: ContractAddress,
     );
 
     /// Archives a token, preserving the on-chain provenance record permanently.
-    /// Archived tokens cannot be transferred or re-archived.
-    /// Only the token owner can archive their token.
-    /// This replaces destructive burning to comply with Berne Convention requirements —
-    /// the legal record of IP creation is never deleted.
-    ///
-    /// # Arguments
-    /// * `token` - The identifier of the token to archive (format: "collection_id:token_id").
-    fn archive(ref self: ContractState, token: ByteArray);
+    /// Archived tokens cannot be transferred or re-archived. Only the token owner can archive.
+    /// Replaces destructive burning — the legal record of IP creation is never deleted.
+    fn archive(ref self: ContractState, collection_id: u256, token_id: u256);
 
-    /// Archives multiple tokens in batch.
-    /// Caller must own all tokens in the batch.
-    ///
-    /// # Arguments
-    /// * `tokens` - Array of token identifiers to archive.
-    fn batch_archive(ref self: ContractState, tokens: Array<ByteArray>);
+    /// Archives multiple tokens (parallel `collection_ids` / `token_ids`, equal length).
+    /// Caller must own every token in the batch.
+    fn batch_archive(ref self: ContractState, collection_ids: Array<u256>, token_ids: Array<u256>);
 
-    /// Transfers a `token` from `from` address to `to` address.
-    /// The IPCollection contract must be approved for the token.
-    /// The caller must be the token owner or an approved operator.
-    ///
-    /// # Arguments
-    /// * `from` - Current owner of the token.
-    /// * `to` - Recipient of the token.
-    /// * `token` - Identifier of the token to transfer.
+    /// Transfers a token to `to`. The IPCollection contract must be approved for the token,
+    /// and the caller must be the token owner or an approved operator. (`from` is derived
+    /// from on-chain ownership.)
     fn transfer_token(
-        ref self: ContractState, from: ContractAddress, to: ContractAddress, token: ByteArray,
+        ref self: ContractState, to: ContractAddress, collection_id: u256, token_id: u256,
     );
 
-    /// Transfers multiple `tokens` from `from` address to `to` address in batch.
-    /// The IPCollection contract must be approved for each token.
-    /// The caller must be the token owner or an approved operator.
-    ///
-    /// # Arguments
-    /// * `from` - Current owner of the tokens.
-    /// * `to` - Recipient of the tokens.
-    /// * `tokens` - Array of token identifiers to transfer.
+    /// Batch transfers tokens (parallel `collection_ids` / `token_ids`, equal length) from
+    /// `from` to `to`. The contract must be approved and the caller authorized for each token.
     fn batch_transfer(
         ref self: ContractState,
         from: ContractAddress,
         to: ContractAddress,
-        tokens: Array<ByteArray>,
+        collection_ids: Array<u256>,
+        token_ids: Array<u256>,
     );
 
     /// Lists all token IDs owned by `user` in a specific `collection_id`.
-    ///
-    /// # Arguments
-    /// * `collection_id` - The identifier of the collection.
-    /// * `user` - The address whose tokens are to be listed.
-    ///
-    /// # Returns
-    /// A Span of token IDs (`u256`).
     fn list_user_tokens_per_collection(
         self: @ContractState, collection_id: u256, user: ContractAddress,
     ) -> Span<u256>;
 
     /// Lists all collection IDs owned by `user`.
-    ///
-    /// # Arguments
-    /// * `user` - The address whose collections are to be listed.
-    ///
-    /// # Returns
-    /// A Span of collection IDs (`u256`).
     fn list_user_collections(self: @ContractState, user: ContractAddress) -> Span<u256>;
 
     /// Retrieves the metadata of a collection by its `collection_id`.
-    ///
-    /// # Arguments
-    /// * `collection_id` - The identifier of the collection.
-    ///
-    /// # Returns
-    /// A `Collection` struct.
     fn get_collection(self: @ContractState, collection_id: u256) -> Collection;
 
     /// Returns the total number of collections ever created.
-    ///
-    /// # Returns
-    /// * `u256` - Total collection count.
     fn get_collection_count(self: @ContractState) -> u256;
 
+    /// Returns the immutable implementation version for this deployed registry class.
+    fn version(self: @ContractState) -> ByteArray;
+
     /// Checks if a `collection_id` exists.
-    ///
-    /// # Arguments
-    /// * `collection_id` - The identifier of the collection.
-    ///
-    /// # Returns
-    /// `true` if valid, `false` otherwise.
     fn is_valid_collection(self: @ContractState, collection_id: u256) -> bool;
 
     /// Retrieves statistics for a collection by its `collection_id`.
-    ///
-    /// # Arguments
-    /// * `collection_id` - The identifier of the collection.
-    ///
-    /// # Returns
-    /// A `CollectionStats` struct.
     fn get_collection_stats(self: @ContractState, collection_id: u256) -> CollectionStats;
 
-    /// Checks if the given `owner` address is the owner of the specified `collection_id`.
-    ///
-    /// # Arguments
-    /// * `collection_id` - The identifier of the collection.
-    /// * `owner` - The address to check for ownership.
-    ///
-    /// # Returns
-    /// `true` if the address is the owner, `false` otherwise.
+    /// Checks if `owner` owns the specified `collection_id`.
     fn is_collection_owner(
         self: @ContractState, collection_id: u256, owner: ContractAddress,
     ) -> bool;
 
     /// Retrieves the full token data including immutable legal record fields.
     /// Reverts if the collection is invalid or the token does not exist.
-    ///
-    /// # Arguments
-    /// * `token` - The identifier of the token (format: "collection_id:token_id").
-    ///
-    /// # Returns
-    /// A `TokenData` struct including `original_creator` and `registered_at`.
-    fn get_token(self: @ContractState, token: ByteArray) -> TokenData;
+    fn get_token(self: @ContractState, collection_id: u256, token_id: u256) -> TokenData;
 
-    /// Checks if a `token` identifier is valid (exists in a valid collection).
-    ///
-    /// # Arguments
-    /// * `token` - The identifier of the token.
-    ///
-    /// # Returns
-    /// `true` if valid, `false` otherwise.
-    fn is_valid_token(self: @ContractState, token: ByteArray) -> bool;
+    /// Checks if a token is valid (exists in a valid collection).
+    fn is_valid_token(self: @ContractState, collection_id: u256, token_id: u256) -> bool;
 
-    /// Checks if a `token` identifier exists and is not archived.
-    /// Use this for trade/transfer eligibility checks.
-    ///
-    /// # Arguments
-    /// * `token` - The identifier of the token.
-    ///
-    /// # Returns
-    /// `true` if the token exists and has not been archived, `false` otherwise.
-    fn is_transferable_token(self: @ContractState, token: ByteArray) -> bool;
-
+    /// Checks if a token exists and is not archived. Use for trade/transfer eligibility.
+    fn is_transferable_token(self: @ContractState, collection_id: u256, token_id: u256) -> bool;
 }

--- a/contracts/MIP-Collections-ERC721/src/interfaces/IIPNFT.cairo
+++ b/contracts/MIP-Collections-ERC721/src/interfaces/IIPNFT.cairo
@@ -11,12 +11,15 @@ pub trait IIPNft<ContractState> {
     /// * `token_id` - The unique identifier for the token to be minted (must be > 0).
     /// * `token_uri` - The immutable URI/string for the token's metadata.
     /// * `creator` - The original IP creator/author recorded immutably at mint time.
+    /// * `royalty_bps` - EIP-2981 secondary-sale royalty in basis points (≤ 10_000), set once
+    ///   for this token with the creator as receiver. Immutable thereafter (no setter).
     fn mint(
         ref self: ContractState,
         recipient: ContractAddress,
         token_id: u256,
         token_uri: ByteArray,
         creator: ContractAddress,
+        royalty_bps: u128,
     );
 
     /// Archives a token, marking it as inactive while preserving the on-chain record permanently.
@@ -47,6 +50,12 @@ pub trait IIPNft<ContractState> {
     /// # Returns
     /// * `ContractAddress` - The registry address.
     fn get_registry(self: @ContractState) -> ContractAddress;
+
+    /// Returns the immutable implementation version for this deployed IPNft class.
+    ///
+    /// # Returns
+    /// * `ByteArray` - The semantic version string (e.g. "0.4.0").
+    fn version(self: @ContractState) -> ByteArray;
 
     /// Returns the base URI of the collection.
     ///

--- a/contracts/MIP-Collections-ERC721/src/types.cairo
+++ b/contracts/MIP-Collections-ERC721/src/types.cairo
@@ -5,62 +5,10 @@ pub const MAX_SYMBOL_LEN: u32 = 64;
 pub const MAX_BASE_URI_LEN: u32 = 2048;
 pub const MAX_TOKEN_URI_LEN: u32 = 2048;
 
-/// Represents a unique identifier for a token within a collection.
-/// The format is `<collection_id:token_id>`, where:
-/// - `collection_id`: The unique identifier of the collection.
-/// - `:`: A separator indicating the token component.
-/// - `token_id`: The unique identifier of the token within the collection.
-#[derive(Drop, Copy, Serde)]
-pub struct Token {
-    /// The unique identifier of the collection.
-    pub collection_id: u256,
-    /// The unique identifier of the token within the collection.
-    pub token_id: u256,
-}
-
-/// Trait implementation for Token, providing utility functions.
-#[generate_trait]
-pub impl TokenImpl of TokenTrait {
-    /// Constructs a `Token` from a `ByteArray` formatted as `<collection_id:token_id>`.
-    /// Exactly one `:` separator must be present and both segments must be non-empty digits.
-    ///
-    /// # Arguments
-    /// * `data` - A `ByteArray` containing the string representation of the token.
-    ///
-    /// # Returns
-    /// * `Token` - The parsed token with `collection_id` and `token_id` fields.
-    fn from_bytes(data: ByteArray) -> Token {
-        let colon: u8 = 58; // ':' in ASCII
-        let mut col_bytes: ByteArray = "";
-        let mut tok_bytes: ByteArray = "";
-        let mut colon_count: u32 = 0;
-
-        // Single pass: count colons and split simultaneously
-        for i in 0..data.len() {
-            let byte = data.at(i).unwrap();
-            if byte == colon {
-                colon_count += 1;
-                continue;
-            }
-            if colon_count == 0 {
-                col_bytes.append_byte(byte);
-            } else {
-                tok_bytes.append_byte(byte);
-            }
-        };
-
-        // Validate: exactly one colon, both segments non-empty
-        assert(
-            colon_count == 1 && col_bytes.len() > 0 && tok_bytes.len() > 0,
-            'Invalid token format',
-        );
-
-        Token {
-            collection_id: bytearray_to_u256(col_bytes),
-            token_id: bytearray_to_u256(tok_bytes),
-        }
-    }
-}
+/// Maximum royalty in basis points (EIP-2981 denominator is 10_000 = 100%).
+/// The contract bound is the protocol-neutral standard maximum; product caps
+/// (e.g. the app's 50%) are enforced at the application layer.
+pub const MAX_ROYALTY_BPS: u128 = 10_000;
 
 /// Represents a collection of tokens with associated metadata and ownership.
 #[derive(Drop, Serde, starknet::Store)]
@@ -101,112 +49,13 @@ pub struct CollectionStats {
     pub total_minted: u256,
     /// Total number of tokens archived in the collection.
     pub total_archived: u256,
-    /// Transfers routed through IPCollection. Direct ERC-721 transfers are emitted by IPNft only.
-    pub total_transfers: u256,
+    /// D-3: transfers routed through IPCollection only. Direct ERC-721 transfers are NOT counted
+    /// here — reconstruct the full transfer history from IPNft `Transfer` events.
+    pub protocol_routed_transfers: u256,
     /// Timestamp of the last mint operation.
     pub last_mint_time: u64,
     /// Timestamp of the last archive operation.
     pub last_archive_time: u64,
     /// Timestamp of the last transfer routed through IPCollection.
     pub last_transfer_time: u64,
-}
-
-/// Converts a `ByteArray` containing only ASCII decimal digits to `u256`.
-/// Panics with a clear message if any non-digit byte is encountered.
-///
-/// # Arguments
-/// * `bytes` - A `ByteArray` representing a decimal number as a string.
-///
-/// # Returns
-/// * `u256` - The parsed unsigned integer value.
-fn bytearray_to_u256(bytes: ByteArray) -> u256 {
-    let mut result = 0_u256;
-    for i in 0..bytes.len() {
-        let byte = bytes.at(i).unwrap();
-        // M-04: validate digit range before subtracting to avoid underflow
-        assert(byte >= 48_u8 && byte <= 57_u8, 'Invalid digit in token ID');
-        let digit = byte - 48;
-        result = result * 10_u256 + digit.into();
-    };
-    result
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_bytearray_to_u256_single_digit() {
-        let data: ByteArray = "7";
-        let result = bytearray_to_u256(data);
-        assert(result == 7_u256, 'single_digit_failed');
-    }
-
-    #[test]
-    fn test_bytearray_to_u256_multiple_digits() {
-        let data: ByteArray = "123456";
-        let result = bytearray_to_u256(data);
-        assert(result == 123456_u256, 'multi_digit_failed');
-    }
-
-    #[test]
-    #[should_panic(expected: ('Invalid digit in token ID',))]
-    fn test_bytearray_to_u256_non_digit_panics() {
-        let data: ByteArray = "12a3";
-        bytearray_to_u256(data);
-    }
-
-    #[test]
-    fn test_token_id_from_bytes_basic() {
-        let data: ByteArray = "42:314";
-        let token_id = TokenTrait::from_bytes(data);
-        assert(token_id.collection_id == 42_u256, 'collection_id_parse_failed');
-        assert(token_id.token_id == 314_u256, 'token_id_parse_failed');
-    }
-
-    #[test]
-    fn test_token_id_from_bytes_large_numbers() {
-        let data: ByteArray = "98765432109876543210:12345678901234567890";
-        let token_id = TokenTrait::from_bytes(data);
-        let expected_col: u256 = 98765432109876543210_u256;
-        let expected_tok: u256 = 12345678901234567890_u256;
-        assert(token_id.collection_id == expected_col, 'large_col_id_failed');
-        assert(token_id.token_id == expected_tok, 'large_token_id_failed');
-    }
-
-    #[test]
-    fn test_token_id_from_bytes_leading_zeros() {
-        let data: ByteArray = "00042:0000314";
-        let token_id = TokenTrait::from_bytes(data);
-        assert(token_id.collection_id == 42_u256, 'leading_zeros_col_failed');
-        assert(token_id.token_id == 314_u256, 'leading_zeros_token_failed');
-    }
-
-    #[test]
-    #[should_panic(expected: ('Invalid token format',))]
-    fn test_from_bytes_no_separator_panics() {
-        let data: ByteArray = "123";
-        TokenTrait::from_bytes(data);
-    }
-
-    #[test]
-    #[should_panic(expected: ('Invalid token format',))]
-    fn test_from_bytes_multiple_colons_panics() {
-        let data: ByteArray = "1:2:3";
-        TokenTrait::from_bytes(data);
-    }
-
-    #[test]
-    #[should_panic(expected: ('Invalid token format',))]
-    fn test_from_bytes_leading_colon_panics() {
-        let data: ByteArray = ":123";
-        TokenTrait::from_bytes(data);
-    }
-
-    #[test]
-    #[should_panic(expected: ('Invalid token format',))]
-    fn test_from_bytes_trailing_colon_panics() {
-        let data: ByteArray = "123:";
-        TokenTrait::from_bytes(data);
-    }
 }

--- a/contracts/MIP-Collections-ERC721/tests/IPCollectionTest.cairo
+++ b/contracts/MIP-Collections-ERC721/tests/IPCollectionTest.cairo
@@ -2,16 +2,21 @@ use ip_collection_erc_721::interfaces::IIPCollection::{
     IIPCollectionDispatcher, IIPCollectionDispatcherTrait,
 };
 use ip_collection_erc_721::interfaces::IIPNFT::{IIPNftDispatcher, IIPNftDispatcherTrait};
+use openzeppelin::introspection::interface::{ISRC5Dispatcher, ISRC5DispatcherTrait};
+use openzeppelin::token::common::erc2981::interface::{
+    IERC2981Dispatcher, IERC2981DispatcherTrait, IERC2981_ID,
+};
 use openzeppelin::token::erc721::interface::{
     ERC721ABIDispatcher, ERC721ABIDispatcherTrait, IERC721Dispatcher, IERC721DispatcherTrait,
 };
 use snforge_std::{
-    CheatSpan, ContractClassTrait, DeclareResultTrait, cheat_caller_address,
-    cheat_block_timestamp, declare, start_cheat_caller_address, stop_cheat_caller_address,
+    CheatSpan, ContractClassTrait, DeclareResultTrait, cheat_block_timestamp, cheat_caller_address,
+    declare, start_cheat_caller_address, stop_cheat_caller_address,
 };
 use starknet::ContractAddress;
 
-// ─── Test constants ────────────────────────────────────────────────────────────
+// ─── Test constants
+// ────────────────────────────────────────────────────────────
 
 fn OWNER() -> ContractAddress {
     0x123.try_into().unwrap()
@@ -44,8 +49,10 @@ fn FUTURE_URI() -> ByteArray {
 
 const COLLECTION_ID: u256 = 1;
 const TOKEN_ID: u256 = 1; // R-05: first token ID is now 1
+const ROYALTY_BPS: u128 = 500; // 5% default royalty used across tests
 
-// ─── Helpers ───────────────────────────────────────────────────────────────────
+// ─── Helpers
+// ───────────────────────────────────────────────────────────────────
 
 fn deploy_contract() -> (IIPCollectionDispatcher, ContractAddress) {
     let ip_nft_class_hash = declare("IPNft").unwrap().contract_class();
@@ -71,7 +78,8 @@ fn setup_collection(dispatcher: IIPCollectionDispatcher, ip_address: ContractAdd
     dispatcher.create_collection(name, symbol, base_uri)
 }
 
-// ─── Collection creation ────────────────────────────────────────────────────────
+// ─── Collection creation
+// ────────────────────────────────────────────────────────
 
 #[test]
 fn test_create_collection() {
@@ -99,12 +107,10 @@ fn test_create_multiple_collections() {
     let owner = OWNER();
     start_cheat_caller_address(ip_address, owner);
 
-    let collection_id1 = dispatcher
-        .create_collection("Collection 1", "C1", "ipfs://QmCollection1");
+    let collection_id1 = dispatcher.create_collection("Collection 1", "C1", "ipfs://QmCollection1");
     assert(collection_id1 == 1, 'First collection ID should be 1');
 
-    let collection_id2 = dispatcher
-        .create_collection("Collection 2", "C2", "ipfs://QmCollection2");
+    let collection_id2 = dispatcher.create_collection("Collection 2", "C2", "ipfs://QmCollection2");
     assert(collection_id2 == 2, 'Second ID should be 2');
 
     stop_cheat_caller_address(ip_address);
@@ -126,7 +132,8 @@ fn test_create_collection_empty_symbol() {
     dispatcher.create_collection("My Collection", "", "ipfs://QmMyCollection");
 }
 
-// ─── Mint ──────────────────────────────────────────────────────────────────────
+// ─── Mint
+// ──────────────────────────────────────────────────────────────────────
 
 #[test]
 fn test_mint_token() {
@@ -136,13 +143,12 @@ fn test_mint_token() {
     let collection_id = setup_collection(dispatcher, ip_address);
 
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
-    let token_id = dispatcher.mint(collection_id, recipient, IPFS_URI());
+    let token_id = dispatcher.mint(collection_id, recipient, IPFS_URI(), ROYALTY_BPS);
 
     // R-05: first token ID is 1
     assert(token_id == 1, 'Token ID should be 1');
 
-    let token_key = format!("{}:{}", collection_id, token_id);
-    let token = dispatcher.get_token(token_key);
+    let token = dispatcher.get_token(collection_id, token_id);
     assert(token.collection_id == collection_id, 'Token collection ID mismatch');
     assert(token.token_id == token_id, 'Token ID mismatch');
     assert(token.owner == recipient, 'Token owner mismatch');
@@ -159,7 +165,7 @@ fn test_token_uri_match() {
     let collection_id = setup_collection(dispatcher, ip_address);
 
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
-    let token_id = dispatcher.mint(collection_id, recipient, IPFS_URI());
+    let token_id = dispatcher.mint(collection_id, recipient, IPFS_URI(), ROYALTY_BPS);
     assert(token_id == 1, 'Token ID should be 1');
 
     let collection_data = dispatcher.get_collection(collection_id);
@@ -179,7 +185,7 @@ fn test_mint_not_owner() {
     let recipient = USER2();
     let collection_id = setup_collection(dispatcher, address);
     start_cheat_caller_address(address, non_owner);
-    dispatcher.mint(collection_id, recipient, IPFS_URI());
+    dispatcher.mint(collection_id, recipient, IPFS_URI(), ROYALTY_BPS);
 }
 
 #[test]
@@ -189,7 +195,7 @@ fn test_mint_to_zero_address() {
     let owner = OWNER();
     let collection_id = setup_collection(dispatcher, address);
     start_cheat_caller_address(address, owner);
-    dispatcher.mint(collection_id, ZERO(), IPFS_URI());
+    dispatcher.mint(collection_id, ZERO(), IPFS_URI(), ROYALTY_BPS);
 }
 
 #[test]
@@ -199,7 +205,7 @@ fn test_mint_zero_caller() {
     let recipient = USER1();
     let collection_id = setup_collection(dispatcher, address);
     start_cheat_caller_address(address, ZERO());
-    dispatcher.mint(collection_id, recipient, IPFS_URI());
+    dispatcher.mint(collection_id, recipient, IPFS_URI(), ROYALTY_BPS);
 }
 
 #[test]
@@ -208,9 +214,9 @@ fn test_mint_http_uri_allowed() {
     let owner = OWNER();
     let collection_id = setup_collection(dispatcher, ip_address);
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
-    let token_id = dispatcher.mint(collection_id, USER1(), HTTP_URI());
+    let token_id = dispatcher.mint(collection_id, USER1(), HTTP_URI(), ROYALTY_BPS);
 
-    let token = dispatcher.get_token(format!("{}:{}", collection_id, token_id));
+    let token = dispatcher.get_token(collection_id, token_id);
     assert(token.metadata_uri == HTTP_URI(), 'HTTP URI mismatch');
 }
 
@@ -220,7 +226,7 @@ fn test_mint_valid_ar_uri() {
     let owner = OWNER();
     let collection_id = setup_collection(dispatcher, ip_address);
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
-    let token_id = dispatcher.mint(collection_id, USER1(), AR_URI());
+    let token_id = dispatcher.mint(collection_id, USER1(), AR_URI(), ROYALTY_BPS);
     assert(token_id == 1, 'ar:// URI should be accepted');
 }
 
@@ -230,9 +236,9 @@ fn test_mint_future_uri_scheme_allowed() {
     let owner = OWNER();
     let collection_id = setup_collection(dispatcher, ip_address);
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
-    let token_id = dispatcher.mint(collection_id, USER1(), FUTURE_URI());
+    let token_id = dispatcher.mint(collection_id, USER1(), FUTURE_URI(), ROYALTY_BPS);
 
-    let token = dispatcher.get_token(format!("{}:{}", collection_id, token_id));
+    let token = dispatcher.get_token(collection_id, token_id);
     assert(token.metadata_uri == FUTURE_URI(), 'Future URI mismatch');
 }
 
@@ -243,10 +249,90 @@ fn test_mint_empty_uri_rejected() {
     let owner = OWNER();
     let collection_id = setup_collection(dispatcher, ip_address);
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
-    dispatcher.mint(collection_id, USER1(), "");
+    dispatcher.mint(collection_id, USER1(), "", ROYALTY_BPS);
 }
 
-// ─── Batch mint ────────────────────────────────────────────────────────────────
+// ─── EIP-2981 royalties (F-1)
+// ──────────────────────────────────────────────────
+
+#[test]
+fn test_mint_sets_token_royalty() {
+    let (dispatcher, ip_address) = deploy_contract();
+    let owner = OWNER();
+    let collection_id = setup_collection(dispatcher, ip_address);
+    cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
+    let token_id = dispatcher.mint(collection_id, USER1(), IPFS_URI(), ROYALTY_BPS);
+
+    let collection_data = dispatcher.get_collection(collection_id);
+    let royalty = IERC2981Dispatcher { contract_address: collection_data.ip_nft };
+    // 5% of a 10_000 sale price = 500; receiver is the immutable creator (collection owner).
+    let (receiver, amount) = royalty.royalty_info(token_id, 10000_u256);
+    assert(receiver == owner, 'Royalty receiver = creator');
+    assert(amount == 500_u256, 'Royalty amount = 5%');
+}
+
+#[test]
+fn test_royalty_receiver_unchanged_after_transfer() {
+    // Royalty receiver must stay the immutable creator even after the token changes hands.
+    let (dispatcher, ip_address) = deploy_contract();
+    let owner = OWNER();
+    let holder = USER1();
+    let buyer = USER2();
+    let collection_id = setup_collection(dispatcher, ip_address);
+
+    cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
+    let token_id = dispatcher.mint(collection_id, holder, IPFS_URI(), ROYALTY_BPS);
+
+    let collection_data = dispatcher.get_collection(collection_id);
+    let erc721 = IERC721Dispatcher { contract_address: collection_data.ip_nft };
+    cheat_caller_address(collection_data.ip_nft, holder, CheatSpan::TargetCalls(1));
+    erc721.approve(ip_address, token_id);
+
+    cheat_caller_address(ip_address, holder, CheatSpan::TargetCalls(1));
+    dispatcher.transfer_token(buyer, collection_id, token_id);
+
+    let royalty = IERC2981Dispatcher { contract_address: collection_data.ip_nft };
+    let (receiver, _) = royalty.royalty_info(token_id, 10000_u256);
+    assert(receiver == owner, 'Receiver must stay creator');
+}
+
+#[test]
+fn test_zero_royalty_allowed() {
+    let (dispatcher, ip_address) = deploy_contract();
+    let owner = OWNER();
+    let collection_id = setup_collection(dispatcher, ip_address);
+    cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
+    let token_id = dispatcher.mint(collection_id, USER1(), IPFS_URI(), 0);
+
+    let collection_data = dispatcher.get_collection(collection_id);
+    let royalty = IERC2981Dispatcher { contract_address: collection_data.ip_nft };
+    let (receiver, amount) = royalty.royalty_info(token_id, 10000_u256);
+    assert(receiver == owner, 'Receiver = creator even at 0');
+    assert(amount == 0_u256, 'Zero royalty pays nothing');
+}
+
+#[test]
+#[should_panic(expected: ('Royalty bps too high',))]
+fn test_mint_rejects_excessive_royalty() {
+    let (dispatcher, ip_address) = deploy_contract();
+    let owner = OWNER();
+    let collection_id = setup_collection(dispatcher, ip_address);
+    cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
+    // > 10_000 bps (100%) must be rejected
+    dispatcher.mint(collection_id, USER1(), IPFS_URI(), 10001);
+}
+
+#[test]
+fn test_supports_erc2981_interface() {
+    let (dispatcher, ip_address) = deploy_contract();
+    let collection_id = setup_collection(dispatcher, ip_address);
+    let collection_data = dispatcher.get_collection(collection_id);
+    let src5 = ISRC5Dispatcher { contract_address: collection_data.ip_nft };
+    assert(src5.supports_interface(IERC2981_ID), 'Must advertise EIP-2981');
+}
+
+// ─── Batch mint
+// ────────────────────────────────────────────────────────────────
 
 #[test]
 fn test_batch_mint_tokens() {
@@ -257,14 +343,15 @@ fn test_batch_mint_tokens() {
     let collection_id = setup_collection(dispatcher, ip_address);
     let token_uris = array![IPFS_URI(), IPFS_URI()];
     let recipients = array![recipient1, recipient2];
+    let royalties = array![ROYALTY_BPS, ROYALTY_BPS];
 
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
-    let token_ids = dispatcher.batch_mint(collection_id, recipients.clone(), token_uris);
+    let token_ids = dispatcher.batch_mint(collection_id, recipients.clone(), token_uris, royalties);
 
     assert(token_ids.len() == 2, 'Should mint 2 tokens in batch');
 
-    let token0 = dispatcher.get_token(format!("{}:{}", collection_id, *token_ids.at(0)));
-    let token1 = dispatcher.get_token(format!("{}:{}", collection_id, *token_ids.at(1)));
+    let token0 = dispatcher.get_token(collection_id, *token_ids.at(0));
+    let token1 = dispatcher.get_token(collection_id, *token_ids.at(1));
 
     assert(token0.owner == recipient1, 'First token owner mismatch');
     assert(token1.owner == recipient2, 'Second token owner mismatch');
@@ -282,7 +369,7 @@ fn test_batch_mint_empty_recipients() {
     let owner = OWNER();
     let collection_id = setup_collection(dispatcher, ip_address);
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
-    dispatcher.batch_mint(collection_id, array![], array![]);
+    dispatcher.batch_mint(collection_id, array![], array![], array![]);
 }
 
 #[test]
@@ -293,7 +380,30 @@ fn test_batch_mint_length_mismatch() {
     let collection_id = setup_collection(dispatcher, ip_address);
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
     // 2 recipients but only 1 URI
-    dispatcher.batch_mint(collection_id, array![USER1(), USER2()], array![IPFS_URI()]);
+    dispatcher
+        .batch_mint(
+            collection_id,
+            array![USER1(), USER2()],
+            array![IPFS_URI()],
+            array![ROYALTY_BPS, ROYALTY_BPS],
+        );
+}
+
+#[test]
+#[should_panic(expected: ('Array lengths mismatch',))]
+fn test_batch_mint_royalty_length_mismatch() {
+    let (dispatcher, ip_address) = deploy_contract();
+    let owner = OWNER();
+    let collection_id = setup_collection(dispatcher, ip_address);
+    cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
+    // 2 recipients, 2 URIs, but only 1 royalty
+    dispatcher
+        .batch_mint(
+            collection_id,
+            array![USER1(), USER2()],
+            array![IPFS_URI(), IPFS_URI()],
+            array![ROYALTY_BPS],
+        );
 }
 
 #[test]
@@ -303,10 +413,11 @@ fn test_batch_mint_zero_recipient() {
     let owner = OWNER();
     let collection_id = setup_collection(dispatcher, ip_address);
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
-    dispatcher.batch_mint(collection_id, array![ZERO()], array![IPFS_URI()]);
+    dispatcher.batch_mint(collection_id, array![ZERO()], array![IPFS_URI()], array![ROYALTY_BPS]);
 }
 
-// ─── Archive (replaces burn) ────────────────────────────────────────────────────
+// ─── Archive (replaces burn)
+// ────────────────────────────────────────────────────
 
 #[test]
 fn test_archive_token() {
@@ -318,11 +429,10 @@ fn test_archive_token() {
     cheat_block_timestamp(collection_data.ip_nft, 1700000000, CheatSpan::TargetCalls(5));
 
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
-    let token_id = dispatcher.mint(collection_id, recipient, IPFS_URI());
+    let token_id = dispatcher.mint(collection_id, recipient, IPFS_URI(), ROYALTY_BPS);
 
-    let token_key = format!("{}:{}", collection_id, token_id);
     cheat_caller_address(ip_address, recipient, CheatSpan::TargetCalls(1));
-    dispatcher.archive(token_key);
+    dispatcher.archive(collection_id, token_id);
 }
 
 #[test]
@@ -335,11 +445,10 @@ fn test_archive_preserves_record() {
     cheat_block_timestamp(collection_data.ip_nft, 1700000000, CheatSpan::TargetCalls(5));
 
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
-    let token_id = dispatcher.mint(collection_id, recipient, IPFS_URI());
+    let token_id = dispatcher.mint(collection_id, recipient, IPFS_URI(), ROYALTY_BPS);
 
-    let token_key = format!("{}:{}", collection_id, token_id);
     cheat_caller_address(ip_address, recipient, CheatSpan::TargetCalls(1));
-    dispatcher.archive(token_key.clone());
+    dispatcher.archive(collection_id, token_id);
 
     // COMP-05: after archiving, the legal record must still be queryable
     let nft = IIPNftDispatcher { contract_address: collection_data.ip_nft };
@@ -362,11 +471,10 @@ fn test_archived_token_transfer_blocked() {
     let collection_id = setup_collection(dispatcher, ip_address);
 
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
-    let token_id = dispatcher.mint(collection_id, from_user, IPFS_URI());
+    let token_id = dispatcher.mint(collection_id, from_user, IPFS_URI(), ROYALTY_BPS);
 
-    let token_key = format!("{}:{}", collection_id, token_id);
     cheat_caller_address(ip_address, from_user, CheatSpan::TargetCalls(1));
-    dispatcher.archive(token_key.clone());
+    dispatcher.archive(collection_id, token_id);
 
     // Attempt to approve and transfer an archived token — must fail
     let collection_data = dispatcher.get_collection(collection_id);
@@ -375,7 +483,7 @@ fn test_archived_token_transfer_blocked() {
     erc721.approve(ip_address, token_id);
 
     cheat_caller_address(ip_address, from_user, CheatSpan::TargetCalls(1));
-    dispatcher.transfer_token(from_user, to_user, token_key);
+    dispatcher.transfer_token(to_user, collection_id, token_id);
 }
 
 #[test]
@@ -388,11 +496,10 @@ fn test_archive_not_owner() {
     let collection_id = setup_collection(dispatcher, ip_address);
 
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
-    let token_id = dispatcher.mint(collection_id, recipient, IPFS_URI());
+    let token_id = dispatcher.mint(collection_id, recipient, IPFS_URI(), ROYALTY_BPS);
 
-    let token_key = format!("{}:{}", collection_id, token_id);
     cheat_caller_address(ip_address, non_owner, CheatSpan::TargetCalls(1));
-    dispatcher.archive(token_key);
+    dispatcher.archive(collection_id, token_id);
 }
 
 #[test]
@@ -405,15 +512,15 @@ fn test_batch_archive_unauthorized() {
     let collection_id = setup_collection(dispatcher, ip_address);
 
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
-    let token_id = dispatcher.mint(collection_id, recipient, IPFS_URI());
+    let token_id = dispatcher.mint(collection_id, recipient, IPFS_URI(), ROYALTY_BPS);
 
     // C-01 regression: attacker tries to batch_archive token they don't own
-    let token_key = format!("{}:{}", collection_id, token_id);
     cheat_caller_address(ip_address, attacker, CheatSpan::TargetCalls(1));
-    dispatcher.batch_archive(array![token_key]);
+    dispatcher.batch_archive(array![collection_id], array![token_id]);
 }
 
-// ─── Transfer ──────────────────────────────────────────────────────────────────
+// ─── Transfer
+// ──────────────────────────────────────────────────────────────────
 
 #[test]
 fn test_transfer_token_success() {
@@ -424,7 +531,7 @@ fn test_transfer_token_success() {
     let collection_id = setup_collection(dispatcher, ip_address);
 
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
-    let token_id = dispatcher.mint(collection_id, from_user, IPFS_URI());
+    let token_id = dispatcher.mint(collection_id, from_user, IPFS_URI(), ROYALTY_BPS);
 
     let collection_data = dispatcher.get_collection(collection_id);
     let erc721_dispatcher = IERC721Dispatcher { contract_address: collection_data.ip_nft };
@@ -432,9 +539,10 @@ fn test_transfer_token_success() {
     cheat_caller_address(collection_data.ip_nft, from_user, CheatSpan::TargetCalls(1));
     erc721_dispatcher.approve(ip_address, token_id);
 
-    let token_key = format!("{}:{}", collection_id, token_id);
     cheat_caller_address(ip_address, from_user, CheatSpan::TargetCalls(1));
-    dispatcher.transfer_token(from_user, to_user, token_key);
+    dispatcher.transfer_token(to_user, collection_id, token_id);
+
+    assert(erc721_dispatcher.owner_of(token_id) == to_user, 'Transfer failed');
 }
 
 #[test]
@@ -446,7 +554,7 @@ fn test_transfer_token_accepts_operator_approval_for_collection_contract() {
     let collection_id = setup_collection(dispatcher, ip_address);
 
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
-    let token_id = dispatcher.mint(collection_id, from_user, IPFS_URI());
+    let token_id = dispatcher.mint(collection_id, from_user, IPFS_URI(), ROYALTY_BPS);
 
     let collection_data = dispatcher.get_collection(collection_id);
     let erc721 = IERC721Dispatcher { contract_address: collection_data.ip_nft };
@@ -454,9 +562,8 @@ fn test_transfer_token_accepts_operator_approval_for_collection_contract() {
     cheat_caller_address(collection_data.ip_nft, from_user, CheatSpan::TargetCalls(1));
     erc721.set_approval_for_all(ip_address, true);
 
-    let token_key = format!("{}:{}", collection_id, token_id);
     cheat_caller_address(ip_address, from_user, CheatSpan::TargetCalls(1));
-    dispatcher.transfer_token(from_user, to_user, token_key);
+    dispatcher.transfer_token(to_user, collection_id, token_id);
 
     assert(erc721.owner_of(token_id) == to_user, 'Operator transfer failed');
 }
@@ -471,12 +578,11 @@ fn test_transfer_token_not_approved() {
     let collection_id = setup_collection(dispatcher, address);
 
     start_cheat_caller_address(address, owner);
-    let token_id = dispatcher.mint(collection_id, from_user, IPFS_URI());
+    let token_id = dispatcher.mint(collection_id, from_user, IPFS_URI(), ROYALTY_BPS);
     stop_cheat_caller_address(address);
 
     start_cheat_caller_address(address, from_user);
-    let token_key = format!("{}:{}", collection_id, token_id);
-    dispatcher.transfer_token(from_user, to_user, token_key);
+    dispatcher.transfer_token(to_user, collection_id, token_id);
 }
 
 #[test]
@@ -491,7 +597,7 @@ fn test_transfer_token_unauthorized_caller() {
     let collection_id = setup_collection(dispatcher, ip_address);
 
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
-    let token_id = dispatcher.mint(collection_id, from_user, IPFS_URI());
+    let token_id = dispatcher.mint(collection_id, from_user, IPFS_URI(), ROYALTY_BPS);
 
     let collection_data = dispatcher.get_collection(collection_id);
     let erc721 = IERC721Dispatcher { contract_address: collection_data.ip_nft };
@@ -501,9 +607,8 @@ fn test_transfer_token_unauthorized_caller() {
     erc721.approve(ip_address, token_id);
 
     // attacker calls transfer_token — must fail
-    let token_key = format!("{}:{}", collection_id, token_id);
     cheat_caller_address(ip_address, attacker, CheatSpan::TargetCalls(1));
-    dispatcher.transfer_token(from_user, to_user, token_key);
+    dispatcher.transfer_token(to_user, collection_id, token_id);
 }
 
 #[test]
@@ -516,17 +621,16 @@ fn test_transfer_token_invalid_collection() {
     let collection_id = setup_collection(dispatcher, ip_address);
 
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
-    let token_id = dispatcher.mint(collection_id, from_user, IPFS_URI());
+    let token_id = dispatcher.mint(collection_id, from_user, IPFS_URI(), ROYALTY_BPS);
 
     cheat_caller_address(ip_address, from_user, CheatSpan::TargetCalls(1));
     // Use a non-existent collection ID
-    let token_key = format!("{}:{}", collection_id + 1, token_id);
-    dispatcher.transfer_token(from_user, to_user, token_key);
+    dispatcher.transfer_token(to_user, collection_id + 1, token_id);
 }
 
 #[test]
 fn test_transfer_stats_updated() {
-    // R-03 regression: total_transfers must be updated after transfer
+    // R-03 regression: protocol_routed_transfers must be updated after transfer
     let (dispatcher, ip_address) = deploy_contract();
     let owner = OWNER();
     let from_user = USER1();
@@ -534,22 +638,22 @@ fn test_transfer_stats_updated() {
     let collection_id = setup_collection(dispatcher, ip_address);
 
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
-    let token_id = dispatcher.mint(collection_id, from_user, IPFS_URI());
+    let token_id = dispatcher.mint(collection_id, from_user, IPFS_URI(), ROYALTY_BPS);
 
     let collection_data = dispatcher.get_collection(collection_id);
     let erc721 = IERC721Dispatcher { contract_address: collection_data.ip_nft };
     cheat_caller_address(collection_data.ip_nft, from_user, CheatSpan::TargetCalls(1));
     erc721.approve(ip_address, token_id);
 
-    let token_key = format!("{}:{}", collection_id, token_id);
     cheat_caller_address(ip_address, from_user, CheatSpan::TargetCalls(1));
-    dispatcher.transfer_token(from_user, to_user, token_key);
+    dispatcher.transfer_token(to_user, collection_id, token_id);
 
     let stats = dispatcher.get_collection_stats(collection_id);
-    assert(stats.total_transfers == 1, 'total_transfers should be 1');
+    assert(stats.protocol_routed_transfers == 1, 'routed transfers should be 1');
 }
 
-// ─── Batch transfer ─────────────────────────────────────────────────────────────
+// ─── Batch transfer
+// ─────────────────────────────────────────────────────────────
 
 #[test]
 fn test_batch_transfer_tokens_success() {
@@ -561,7 +665,12 @@ fn test_batch_transfer_tokens_success() {
 
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
     let token_ids = dispatcher
-        .batch_mint(collection_id, array![from_user, from_user], array![IPFS_URI(), IPFS_URI()]);
+        .batch_mint(
+            collection_id,
+            array![from_user, from_user],
+            array![IPFS_URI(), IPFS_URI()],
+            array![ROYALTY_BPS, ROYALTY_BPS],
+        );
 
     let collection_data = dispatcher.get_collection(collection_id);
     let erc721 = IERC721Dispatcher { contract_address: collection_data.ip_nft };
@@ -570,15 +679,17 @@ fn test_batch_transfer_tokens_success() {
     erc721.approve(ip_address, *token_ids.at(0));
     erc721.approve(ip_address, *token_ids.at(1));
 
-    let token0 = format!("{}:{}", collection_id, *token_ids.at(0));
-    let token1 = format!("{}:{}", collection_id, *token_ids.at(1));
-    let tokens = array![token0, token1];
-
     cheat_caller_address(ip_address, from_user, CheatSpan::TargetCalls(1));
-    dispatcher.batch_transfer(from_user, to_user, tokens.clone());
+    dispatcher
+        .batch_transfer(
+            from_user,
+            to_user,
+            array![collection_id, collection_id],
+            array![*token_ids.at(0), *token_ids.at(1)],
+        );
 
-    let token_data0 = dispatcher.get_token(tokens.clone().at(0).clone());
-    let token_data1 = dispatcher.get_token(tokens.clone().at(1_u32).clone());
+    let token_data0 = dispatcher.get_token(collection_id, *token_ids.at(0));
+    let token_data1 = dispatcher.get_token(collection_id, *token_ids.at(1));
     assert(token_data0.owner == to_user, 'Token0 should be transferred');
     assert(token_data1.owner == to_user, 'Token1 should be transferred');
 }
@@ -595,11 +706,10 @@ fn test_batch_transfer_not_approved() {
 
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
     let token_ids = dispatcher
-        .batch_mint(collection_id, array![from_user], array![IPFS_URI()]);
+        .batch_mint(collection_id, array![from_user], array![IPFS_URI()], array![ROYALTY_BPS]);
 
-    let token_key = format!("{}:{}", collection_id, *token_ids.at(0));
     cheat_caller_address(ip_address, from_user, CheatSpan::TargetCalls(1));
-    dispatcher.batch_transfer(from_user, to_user, array![token_key]);
+    dispatcher.batch_transfer(from_user, to_user, array![collection_id], array![*token_ids.at(0)]);
 }
 
 #[test]
@@ -614,16 +724,16 @@ fn test_batch_transfer_unauthorized_caller() {
     let collection_id = setup_collection(dispatcher, ip_address);
 
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
-    let token_ids = dispatcher.batch_mint(collection_id, array![from_user], array![IPFS_URI()]);
+    let token_ids = dispatcher
+        .batch_mint(collection_id, array![from_user], array![IPFS_URI()], array![ROYALTY_BPS]);
 
     let collection_data = dispatcher.get_collection(collection_id);
     let erc721 = IERC721Dispatcher { contract_address: collection_data.ip_nft };
     cheat_caller_address(collection_data.ip_nft, from_user, CheatSpan::TargetCalls(1));
     erc721.approve(ip_address, *token_ids.at(0));
 
-    let token_key = format!("{}:{}", collection_id, *token_ids.at(0));
     cheat_caller_address(ip_address, attacker, CheatSpan::TargetCalls(1));
-    dispatcher.batch_transfer(from_user, to_user, array![token_key]);
+    dispatcher.batch_transfer(from_user, to_user, array![collection_id], array![*token_ids.at(0)]);
 }
 
 #[test]
@@ -636,11 +746,29 @@ fn test_batch_transfer_invalid_collection() {
     let collection_id = setup_collection(dispatcher, ip_address);
 
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
-    let token_ids = dispatcher.batch_mint(collection_id, array![from_user], array![IPFS_URI()]);
+    let token_ids = dispatcher
+        .batch_mint(collection_id, array![from_user], array![IPFS_URI()], array![ROYALTY_BPS]);
 
-    let token_key = format!("{}:{}", collection_id + 1, *token_ids.at(0));
     cheat_caller_address(ip_address, from_user, CheatSpan::TargetCalls(1));
-    dispatcher.batch_transfer(from_user, to_user, array![token_key]);
+    dispatcher
+        .batch_transfer(from_user, to_user, array![collection_id + 1], array![*token_ids.at(0)]);
+}
+
+#[test]
+#[should_panic(expected: ('Array lengths mismatch',))]
+fn test_batch_transfer_length_mismatch() {
+    let (dispatcher, ip_address) = deploy_contract();
+    let owner = OWNER();
+    let from_user = USER1();
+    let to_user = USER2();
+    let collection_id = setup_collection(dispatcher, ip_address);
+
+    cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
+    dispatcher.mint(collection_id, from_user, IPFS_URI(), ROYALTY_BPS);
+
+    cheat_caller_address(ip_address, from_user, CheatSpan::TargetCalls(1));
+    // 1 collection id but 2 token ids
+    dispatcher.batch_transfer(from_user, to_user, array![collection_id], array![1, 2]);
 }
 
 #[test]
@@ -652,7 +780,7 @@ fn test_direct_erc721_transfer_success_without_protocol_stats() {
     let collection_id = setup_collection(dispatcher, ip_address);
 
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
-    let token_id = dispatcher.mint(collection_id, from_user, IPFS_URI());
+    let token_id = dispatcher.mint(collection_id, from_user, IPFS_URI(), ROYALTY_BPS);
 
     let collection_data = dispatcher.get_collection(collection_id);
     let erc721 = IERC721Dispatcher { contract_address: collection_data.ip_nft };
@@ -662,7 +790,7 @@ fn test_direct_erc721_transfer_success_without_protocol_stats() {
 
     assert(erc721.owner_of(token_id) == to_user, 'Direct transfer failed');
     let stats = dispatcher.get_collection_stats(collection_id);
-    assert(stats.total_transfers == 0, 'Stats changed');
+    assert(stats.protocol_routed_transfers == 0, 'Stats changed');
 }
 
 #[test]
@@ -675,11 +803,10 @@ fn test_direct_erc721_transfer_archived_token_blocked() {
     let collection_id = setup_collection(dispatcher, ip_address);
 
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
-    let token_id = dispatcher.mint(collection_id, from_user, IPFS_URI());
+    let token_id = dispatcher.mint(collection_id, from_user, IPFS_URI(), ROYALTY_BPS);
 
-    let token_key = format!("{}:{}", collection_id, token_id);
     cheat_caller_address(ip_address, from_user, CheatSpan::TargetCalls(1));
-    dispatcher.archive(token_key);
+    dispatcher.archive(collection_id, token_id);
 
     let collection_data = dispatcher.get_collection(collection_id);
     let erc721 = IERC721Dispatcher { contract_address: collection_data.ip_nft };
@@ -688,7 +815,8 @@ fn test_direct_erc721_transfer_archived_token_blocked() {
     erc721.transfer_from(from_user, to_user, token_id);
 }
 
-// ─── Legal record (COMP-02, COMP-03, COMP-06, COMP-07) ─────────────────────────
+// ─── Legal record (COMP-02, COMP-03, COMP-06, COMP-07)
+// ─────────────────────────
 
 #[test]
 fn test_get_token_creator() {
@@ -698,7 +826,7 @@ fn test_get_token_creator() {
     let collection_id = setup_collection(dispatcher, ip_address);
 
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
-    let token_id = dispatcher.mint(collection_id, recipient, IPFS_URI());
+    let token_id = dispatcher.mint(collection_id, recipient, IPFS_URI(), ROYALTY_BPS);
 
     let collection_data = dispatcher.get_collection(collection_id);
     let nft = IIPNftDispatcher { contract_address: collection_data.ip_nft };
@@ -719,11 +847,10 @@ fn test_get_token_registered_at() {
     cheat_block_timestamp(collection_data.ip_nft, 1700000000, CheatSpan::TargetCalls(5));
 
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
-    let token_id = dispatcher.mint(collection_id, recipient, IPFS_URI());
+    let token_id = dispatcher.mint(collection_id, recipient, IPFS_URI(), ROYALTY_BPS);
 
     let nft = IIPNftDispatcher { contract_address: collection_data.ip_nft };
 
-    // registered_at should be stored (non-zero timestamp)
     let registered_at = nft.get_token_registered_at(token_id);
     assert(registered_at != 0, 'registered_at should be stored');
 }
@@ -737,13 +864,11 @@ fn test_token_data_includes_creator_and_timestamp() {
     let collection_id = setup_collection(dispatcher, ip_address);
 
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
-    let token_id = dispatcher.mint(collection_id, recipient, IPFS_URI());
+    let token_id = dispatcher.mint(collection_id, recipient, IPFS_URI(), ROYALTY_BPS);
 
-    let token_key = format!("{}:{}", collection_id, token_id);
-    let token_data = dispatcher.get_token(token_key);
+    let token_data = dispatcher.get_token(collection_id, token_id);
 
     assert(token_data.original_creator == owner, 'original_creator mismatch');
-    // registered_at may be 0 in test env without timestamp cheat — field existence is what matters
     let _ = token_data.registered_at;
 }
 
@@ -757,16 +882,15 @@ fn test_creator_unchanged_after_transfer() {
     let collection_id = setup_collection(dispatcher, ip_address);
 
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
-    let token_id = dispatcher.mint(collection_id, holder, IPFS_URI());
+    let token_id = dispatcher.mint(collection_id, holder, IPFS_URI(), ROYALTY_BPS);
 
     let collection_data = dispatcher.get_collection(collection_id);
     let erc721 = IERC721Dispatcher { contract_address: collection_data.ip_nft };
     cheat_caller_address(collection_data.ip_nft, holder, CheatSpan::TargetCalls(1));
     erc721.approve(ip_address, token_id);
 
-    let token_key = format!("{}:{}", collection_id, token_id);
     cheat_caller_address(ip_address, holder, CheatSpan::TargetCalls(1));
-    dispatcher.transfer_token(holder, buyer, token_key.clone());
+    dispatcher.transfer_token(buyer, collection_id, token_id);
 
     // After transfer, original_creator must still be the minting collection owner
     let nft = IIPNftDispatcher { contract_address: collection_data.ip_nft };
@@ -774,7 +898,8 @@ fn test_creator_unchanged_after_transfer() {
     assert(erc721.owner_of(token_id) == buyer, 'New owner should be buyer');
 }
 
-// ─── Collection immutability ───────────────────────────────────────────────────
+// ─── Collection immutability
+// ───────────────────────────────────────────────────
 
 #[test]
 fn test_collection_metadata_is_immutable_after_creation() {
@@ -805,9 +930,9 @@ fn test_transfer_collection_ownership_updates_owner_and_mint_authority() {
     assert(!dispatcher.is_collection_owner(collection_id, OWNER()), 'Old owner mismatch');
 
     cheat_caller_address(ip_address, USER2(), CheatSpan::TargetCalls(1));
-    let token_id = dispatcher.mint(collection_id, USER1(), IPFS_URI());
+    let token_id = dispatcher.mint(collection_id, USER1(), IPFS_URI(), ROYALTY_BPS);
     assert(token_id == 1, 'New owner should mint');
-    let token = dispatcher.get_token(format!("{}:{}", collection_id, token_id));
+    let token = dispatcher.get_token(collection_id, token_id);
     assert(token.original_creator == USER2(), 'New owner should be creator');
 }
 
@@ -821,7 +946,7 @@ fn test_previous_collection_owner_cannot_mint_after_transfer() {
     dispatcher.transfer_collection_ownership(collection_id, USER2());
 
     cheat_caller_address(ip_address, OWNER(), CheatSpan::TargetCalls(1));
-    dispatcher.mint(collection_id, USER1(), IPFS_URI());
+    dispatcher.mint(collection_id, USER1(), IPFS_URI(), ROYALTY_BPS);
 }
 
 #[test]
@@ -898,33 +1023,33 @@ fn test_get_collection_count() {
     stop_cheat_caller_address(ip_address);
 }
 
-// ─── get_token validation ───────────────────────────────────────────────────────
+// ─── Version
+// ───────────────────────────────────────────────────────
+
+#[test]
+fn test_contract_version() {
+    let (dispatcher, ip_address) = deploy_contract();
+    assert(dispatcher.version() == "0.4.0", 'Registry version mismatch');
+
+    let collection_id = setup_collection(dispatcher, ip_address);
+    let collection_data = dispatcher.get_collection(collection_id);
+    let nft = IIPNftDispatcher { contract_address: collection_data.ip_nft };
+    assert(nft.version() == "0.4.0", 'IPNft version mismatch');
+}
+
+// ─── get_token validation
+// ───────────────────────────────────────────────────────
 
 #[test]
 #[should_panic(expected: ('Invalid collection',))]
 fn test_get_token_invalid_collection_reverts() {
     let (dispatcher, _) = deploy_contract();
     // collection_id 99 was never created
-    dispatcher.get_token("99:1");
+    dispatcher.get_token(99, 1);
 }
 
-// ─── Parser validation (M-04, L-04) ────────────────────────────────────────────
-
-#[test]
-#[should_panic(expected: ('Invalid token format',))]
-fn test_from_bytes_no_colon_panics() {
-    let (dispatcher, _) = deploy_contract();
-    dispatcher.is_valid_token("123");
-}
-
-#[test]
-#[should_panic(expected: ('Invalid token format',))]
-fn test_from_bytes_multiple_colons_panics() {
-    let (dispatcher, _) = deploy_contract();
-    dispatcher.is_valid_token("1:2:3");
-}
-
-// ─── Existing passing tests (preserved / updated) ──────────────────────────────
+// ─── Verification / view functions
+// ─────────────────────────────────────────────
 
 #[test]
 fn test_list_user_collections_empty() {
@@ -940,13 +1065,23 @@ fn test_verification_functions() {
     let collection_id = setup_collection(dispatcher, address);
 
     start_cheat_caller_address(address, owner);
-    let token_id = dispatcher.mint(collection_id, USER1(), IPFS_URI());
-    let token_key = format!("{}:{}", collection_id, token_id);
+    let token_id = dispatcher.mint(collection_id, USER1(), IPFS_URI(), ROYALTY_BPS);
     assert(dispatcher.is_valid_collection(collection_id), 'Collection should be valid');
-    assert(dispatcher.is_valid_token(token_key.clone()), 'Token should be valid');
-    assert(dispatcher.is_transferable_token(token_key), 'Token should be transferable');
+    assert(dispatcher.is_valid_token(collection_id, token_id), 'Token should be valid');
+    assert(
+        dispatcher.is_transferable_token(collection_id, token_id), 'Token should be transferable',
+    );
     assert(dispatcher.is_collection_owner(collection_id, owner), 'Owner should be correct');
     stop_cheat_caller_address(address);
+}
+
+#[test]
+fn test_is_valid_token_false_for_unknown() {
+    let (dispatcher, ip_address) = deploy_contract();
+    let collection_id = setup_collection(dispatcher, ip_address);
+    // never-minted token id, and unknown collection
+    assert(!dispatcher.is_valid_token(collection_id, 999), 'Unknown token not valid');
+    assert(!dispatcher.is_valid_token(99, 1), 'Unknown collection not valid');
 }
 
 #[test]
@@ -963,14 +1098,13 @@ fn test_is_transferable_token_false_after_archive() {
     let collection_id = setup_collection(dispatcher, ip_address);
 
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
-    let token_id = dispatcher.mint(collection_id, recipient, IPFS_URI());
+    let token_id = dispatcher.mint(collection_id, recipient, IPFS_URI(), ROYALTY_BPS);
 
-    let token_key = format!("{}:{}", collection_id, token_id);
     cheat_caller_address(ip_address, recipient, CheatSpan::TargetCalls(1));
-    dispatcher.archive(token_key.clone());
+    dispatcher.archive(collection_id, token_id);
 
-    assert(dispatcher.is_valid_token(token_key.clone()), 'Archived token should exist');
-    assert(!dispatcher.is_transferable_token(token_key), 'Archived token transfers');
+    assert(dispatcher.is_valid_token(collection_id, token_id), 'Archived token should exist');
+    assert(!dispatcher.is_transferable_token(collection_id, token_id), 'Archived token transfers');
 }
 
 #[test]
@@ -1012,14 +1146,10 @@ fn test_user_collections_mapping() {
     );
 
     let user2_collections = ip_dispatcher.list_user_collections(USER2());
-    assert(
-        user2_collections == array![collection_id2, collection_id3].span(), 'mismatch user2',
-    );
+    assert(user2_collections == array![collection_id2, collection_id3].span(), 'mismatch user2');
 
     let user3_collections = ip_dispatcher.list_user_collections(USER3());
-    assert(
-        user3_collections == array![collection_id4, collection_id7].span(), 'mismatch user3',
-    );
+    assert(user3_collections == array![collection_id4, collection_id7].span(), 'mismatch user3');
 }
 
 #[test]
@@ -1029,8 +1159,7 @@ fn test_base_uri() {
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
 
     let base_uri: ByteArray = "ipfs://QmMyCollection";
-    let collection_id = ip_dispatcher
-        .create_collection("My Collection", "MC", base_uri.clone());
+    let collection_id = ip_dispatcher.create_collection("My Collection", "MC", base_uri.clone());
 
     let collection = ip_dispatcher.get_collection(collection_id);
     let collection_base_uri = IIPNftDispatcher { contract_address: collection.ip_nft }.base_uri();
@@ -1047,7 +1176,12 @@ fn test_get_all_user_tokens() {
 
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
     let token_ids = dispatcher
-        .batch_mint(collection_id, array![recipient1, recipient2], array![IPFS_URI(), IPFS_URI()]);
+        .batch_mint(
+            collection_id,
+            array![recipient1, recipient2],
+            array![IPFS_URI(), IPFS_URI()],
+            array![ROYALTY_BPS, ROYALTY_BPS],
+        );
 
     assert(token_ids.len() == 2, 'Should mint 2 tokens in batch');
 
@@ -1056,7 +1190,7 @@ fn test_get_all_user_tokens() {
     assert(*recipient_tokens.at(0) == *token_ids.at(0), 'TokenID mismatch for recipient1');
 
     cheat_caller_address(ip_address, owner, CheatSpan::TargetCalls(1));
-    let token_id3 = dispatcher.mint(collection_id, recipient1, IPFS_URI());
+    let token_id3 = dispatcher.mint(collection_id, recipient1, IPFS_URI(), ROYALTY_BPS);
     assert(token_id3 == 3, 'Token ID should be 3');
 
     let recipients_tokens = dispatcher.list_user_tokens_per_collection(collection_id, recipient1);


### PR DESCRIPTION
Per-token EIP-2981 creator royalties on the MIP ERC-721 registry (receiver = immutable creator, set once at mint, no setter). Adds version() views, (collection_id, token_id) u256 token ops, protocol_routed_transfers, CEI hardening. 64 tests passing. Deployed to Starknet mainnet (registry 0x0558c9b6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)