### PR TITLE
IP-Tickets: programmable license discovery marker + mint-to-recipient

### DIFF
--- a/contracts/IP-Tickets/src/IPTicketCollection.cairo
+++ b/contracts/IP-Tickets/src/IPTicketCollection.cairo
@@ -42,7 +42,7 @@ pub mod IPTicketCollection {
         ownable: OwnableComponent::Storage,
         last_collection_id: u256,
         next_token_id: u256,
-        total_supply: u256,
+        total_minted: u256,
         ticket_collections: Map<u256, TicketCollectionData>,
         token_to_collection: Map<u256, u256>,
         active_ticket_balance: Map<(ContractAddress, u256), u256>,
@@ -95,6 +95,8 @@ pub mod IPTicketCollection {
         pub collection_id: u256,
         #[key]
         pub owner: ContractAddress,
+        // Who paid for the mint — differs from owner on gift/agent mints.
+        pub payer: ContractAddress,
         pub minted_at: u64,
     }
 
@@ -288,7 +290,7 @@ pub mod IPTicketCollection {
             let token_id = self.next_token_id.read();
             self.next_token_id.write(token_id + 1);
             self.token_to_collection.write(token_id, collection_id);
-            self.total_supply.write(self.total_supply.read() + 1);
+            self.total_minted.write(self.total_minted.read() + 1);
 
             // State is final before the external calls (checks-effects-
             // interactions); a reentrant call from the payment token or the
@@ -301,7 +303,11 @@ pub mod IPTicketCollection {
             self
                 .emit(
                     TicketMinted {
-                        token_id, collection_id, owner: recipient, minted_at: get_block_timestamp(),
+                        token_id,
+                        collection_id,
+                        owner: recipient,
+                        payer,
+                        minted_at: get_block_timestamp(),
                     },
                 );
 
@@ -391,7 +397,7 @@ pub mod IPTicketCollection {
         }
 
         fn total_minted(self: @ContractState) -> u256 {
-            self.total_supply.read()
+            self.total_minted.read()
         }
 
         fn version(self: @ContractState) -> ByteArray {

--- a/contracts/IP-Tickets/src/IPTicketCollection.cairo
+++ b/contracts/IP-Tickets/src/IPTicketCollection.cairo
@@ -270,7 +270,9 @@ pub mod IPTicketCollection {
                 );
         }
 
-        fn mint_ticket(ref self: ContractState, collection_id: u256, recipient: ContractAddress) -> u256 {
+        fn mint_ticket(
+            ref self: ContractState, collection_id: u256, recipient: ContractAddress,
+        ) -> u256 {
             let mut collection = self.ticket_collections.read(collection_id);
             assert(!collection.creator.is_zero(), 'Ticket collection not found');
             assert(collection.active, 'Collection is inactive');

--- a/contracts/IP-Tickets/src/IPTicketCollection.cairo
+++ b/contracts/IP-Tickets/src/IPTicketCollection.cairo
@@ -270,15 +270,15 @@ pub mod IPTicketCollection {
                 );
         }
 
-        fn mint_ticket(ref self: ContractState, collection_id: u256) -> u256 {
+        fn mint_ticket(ref self: ContractState, collection_id: u256, recipient: ContractAddress) -> u256 {
             let mut collection = self.ticket_collections.read(collection_id);
             assert(!collection.creator.is_zero(), 'Ticket collection not found');
             assert(collection.active, 'Collection is inactive');
             assert(get_block_timestamp() < collection.expiration, 'Ticket collection expired');
             assert(collection.minted < collection.max_supply, 'Max supply reached');
+            assert(!recipient.is_zero(), 'Recipient is zero address');
 
-            let caller = get_caller_address();
-            assert(!caller.is_zero(), 'Recipient is zero address');
+            let payer = get_caller_address();
 
             collection.minted += 1;
             self.ticket_collections.write(collection_id, collection.clone());
@@ -292,14 +292,14 @@ pub mod IPTicketCollection {
             // interactions); a reentrant call from the payment token or the
             // receiver callback runs under its own caller context against
             // consistent storage.
-            collect_payment(caller, @collection);
+            collect_payment(payer, @collection);
 
-            self.erc721.safe_mint(caller, token_id, array![].span());
+            self.erc721.safe_mint(recipient, token_id, array![].span());
 
             self
                 .emit(
                     TicketMinted {
-                        token_id, collection_id, owner: caller, minted_at: get_block_timestamp(),
+                        token_id, collection_id, owner: recipient, minted_at: get_block_timestamp(),
                     },
                 );
 
@@ -390,6 +390,10 @@ pub mod IPTicketCollection {
 
         fn total_minted(self: @ContractState) -> u256 {
             self.total_supply.read()
+        }
+
+        fn version(self: @ContractState) -> ByteArray {
+            "2.0.0"
         }
 
         fn royalty_info(

--- a/contracts/IP-Tickets/src/IPTicketCollection.cairo
+++ b/contracts/IP-Tickets/src/IPTicketCollection.cairo
@@ -12,7 +12,7 @@ pub mod IPTicketCollection {
         StoragePointerWriteAccess,
     };
     use starknet::{ContractAddress, get_block_timestamp, get_caller_address};
-    use crate::interface::{IIPTicketCollection, IIP_TICKET_COLLECTION_ID};
+    use crate::interface::{IIPTicketCollection, IIP_TICKET_COLLECTION_ID, ILICENSED_COLLECTION_ID};
     use crate::types::{TicketCollection as TicketCollectionData, TicketData, bytearray_starts_with};
 
     component!(path: ERC721Component, storage: erc721, event: ERC721Event);
@@ -122,6 +122,7 @@ pub mod IPTicketCollection {
         self.ownable.initializer(owner);
         self.src5.register_interface(IIP_TICKET_COLLECTION_ID);
         self.src5.register_interface(IERC2981_ID);
+        self.src5.register_interface(ILICENSED_COLLECTION_ID);
         self.next_token_id.write(1);
     }
 

--- a/contracts/IP-Tickets/src/IPTicketCollection.cairo
+++ b/contracts/IP-Tickets/src/IPTicketCollection.cairo
@@ -388,7 +388,7 @@ pub mod IPTicketCollection {
             self.last_collection_id.read()
         }
 
-        fn total_supply(self: @ContractState) -> u256 {
+        fn total_minted(self: @ContractState) -> u256 {
             self.total_supply.read()
         }
 

--- a/contracts/IP-Tickets/src/IPTicketCollectionFactory.cairo
+++ b/contracts/IP-Tickets/src/IPTicketCollectionFactory.cairo
@@ -9,13 +9,22 @@
 pub mod IPTicketCollectionFactory {
     use core::hash::{HashStateExTrait, HashStateTrait};
     use core::poseidon::PoseidonTrait;
+    use openzeppelin_introspection::src5::SRC5Component;
     use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
     use starknet::syscalls::deploy_syscall;
     use starknet::{ClassHash, ContractAddress, SyscallResultTrait, get_caller_address};
-    use crate::interface::IIPTicketCollectionFactory;
+    use crate::interface::{IIPTicketCollectionFactory, IIP_TICKET_COLLECTION_FACTORY_ID};
+
+    component!(path: SRC5Component, storage: src5, event: SRC5Event);
+
+    #[abi(embed_v0)]
+    impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
+    impl SRC5InternalImpl = SRC5Component::InternalImpl<ContractState>;
 
     #[storage]
     struct Storage {
+        #[substorage(v0)]
+        src5: SRC5Component::Storage,
         /// Class hash used to deploy new IPTicketCollection instances.
         /// Immutable — fixed at deploy.
         ip_ticket_collection_class_hash: ClassHash,
@@ -26,6 +35,8 @@ pub mod IPTicketCollectionFactory {
     #[event]
     #[derive(Drop, starknet::Event)]
     pub enum Event {
+        #[flat]
+        SRC5Event: SRC5Component::Event,
         CollectionDeployed: CollectionDeployed,
     }
 
@@ -50,6 +61,7 @@ pub mod IPTicketCollectionFactory {
     #[constructor]
     fn constructor(ref self: ContractState, collection_class_hash: ClassHash) {
         assert(collection_class_hash.into() != 0_felt252, 'Class hash is zero');
+        self.src5.register_interface(IIP_TICKET_COLLECTION_FACTORY_ID);
         self.ip_ticket_collection_class_hash.write(collection_class_hash);
         // deploy_nonce defaults to 0 — no explicit write needed
     }
@@ -61,7 +73,7 @@ pub mod IPTicketCollectionFactory {
         }
 
         fn version(self: @ContractState) -> ByteArray {
-            "1.0.0"
+            "2.0.0"
         }
 
         fn deploy_ticket_collection(

--- a/contracts/IP-Tickets/src/interface.cairo
+++ b/contracts/IP-Tickets/src/interface.cairo
@@ -6,6 +6,14 @@ use crate::types::{TicketCollection, TicketData};
 pub const IIP_TICKET_COLLECTION_ID: felt252 =
     0x329801ec79f9a18a441f490a55694aadd00b57e11fc1f2fc561b9bebc68e3d9;
 
+// Marks a collection whose metadata JSON carries the Mediolano programmable
+// license trait schema (License, Commercial Use, Derivatives, Attribution,
+// Territory, AI Policy, Standard, Registration). Discovery only — the license
+// remains data in metadata, not contract-enforced state.
+// Derivation: starknet_keccak("mediolano.licensed-collection.v1").
+pub const ILICENSED_COLLECTION_ID: felt252 =
+    0x3aaa3269207d0d03ca389e2a76f46c207ff513c2503ba463805d76ce52d75b8;
+
 #[starknet::interface]
 pub trait IIPTicketCollection<TContractState> {
     fn create_ticket_collection(

--- a/contracts/IP-Tickets/src/interface.cairo
+++ b/contracts/IP-Tickets/src/interface.cairo
@@ -1,10 +1,13 @@
 use starknet::{ClassHash, ContractAddress};
 use crate::types::{TicketCollection, TicketData};
 
-// Protocol discovery ID registered via SRC5.
-// Derivation: starknet_keccak("mediolano.ip-ticket-collection.v1").
+// Protocol discovery ID registered via SRC5. Bumped to .v2 with the
+// breaking ABI change (mint_ticket recipient param, total_supply →
+// total_minted): immutable v1 deployments keep registering the .v1 ID,
+// so consumers can tell the two ABIs apart via SRC5 alone.
+// Derivation: starknet_keccak("mediolano.ip-ticket-collection.v2").
 pub const IIP_TICKET_COLLECTION_ID: felt252 =
-    0x329801ec79f9a18a441f490a55694aadd00b57e11fc1f2fc561b9bebc68e3d9;
+    0x1ef1511f39449df0a0c686da9bc0759e7c75ad8eb0da68c53ac14093a6ea757;
 
 // Marks a collection whose metadata JSON carries the Mediolano programmable
 // license trait schema (License, Commercial Use, Derivatives, Attribution,

--- a/contracts/IP-Tickets/src/interface.cairo
+++ b/contracts/IP-Tickets/src/interface.cairo
@@ -28,7 +28,7 @@ pub trait IIPTicketCollection<TContractState> {
 
     fn set_collection_active(ref self: TContractState, collection_id: u256, active: bool);
 
-    fn mint_ticket(ref self: TContractState, collection_id: u256) -> u256;
+    fn mint_ticket(ref self: TContractState, collection_id: u256, recipient: ContractAddress) -> u256;
 
     fn redeem_ticket(ref self: TContractState, token_id: u256);
 
@@ -47,6 +47,8 @@ pub trait IIPTicketCollection<TContractState> {
     fn get_last_collection_id(self: @TContractState) -> u256;
 
     fn total_minted(self: @TContractState) -> u256;
+
+    fn version(self: @TContractState) -> ByteArray;
 
     fn royalty_info(
         self: @TContractState, token_id: u256, sale_price: u256,

--- a/contracts/IP-Tickets/src/interface.cairo
+++ b/contracts/IP-Tickets/src/interface.cairo
@@ -46,7 +46,7 @@ pub trait IIPTicketCollection<TContractState> {
 
     fn get_last_collection_id(self: @TContractState) -> u256;
 
-    fn total_supply(self: @TContractState) -> u256;
+    fn total_minted(self: @TContractState) -> u256;
 
     fn royalty_info(
         self: @TContractState, token_id: u256, sale_price: u256,

--- a/contracts/IP-Tickets/src/interface.cairo
+++ b/contracts/IP-Tickets/src/interface.cairo
@@ -28,7 +28,9 @@ pub trait IIPTicketCollection<TContractState> {
 
     fn set_collection_active(ref self: TContractState, collection_id: u256, active: bool);
 
-    fn mint_ticket(ref self: TContractState, collection_id: u256, recipient: ContractAddress) -> u256;
+    fn mint_ticket(
+        ref self: TContractState, collection_id: u256, recipient: ContractAddress,
+    ) -> u256;
 
     fn redeem_ticket(ref self: TContractState, token_id: u256);
 

--- a/contracts/IP-Tickets/src/mock/reentrant_payment_token.cairo
+++ b/contracts/IP-Tickets/src/mock/reentrant_payment_token.cairo
@@ -44,7 +44,7 @@ pub mod ReentrantPaymentToken {
             let ticket_collection = IIPTicketCollectionDispatcher {
                 contract_address: self.ticket_collection.read(),
             };
-            ticket_collection.mint_ticket(self.collection_id.read());
+            ticket_collection.mint_ticket(self.collection_id.read(), sender);
             true
         }
     }

--- a/contracts/IP-Tickets/tests/test_ipticket_collection.cairo
+++ b/contracts/IP-Tickets/tests/test_ipticket_collection.cairo
@@ -1,5 +1,6 @@
 use ip_ticket::interface::{
     IIPTicketCollectionDispatcher, IIPTicketCollectionDispatcherTrait, IIP_TICKET_COLLECTION_ID,
+    ILICENSED_COLLECTION_ID,
 };
 use ip_ticket::mock::mock_erc20::{IERC20MintDispatcher, IERC20MintDispatcherTrait};
 use openzeppelin_introspection::interface::{ISRC5Dispatcher, ISRC5DispatcherTrait};
@@ -489,4 +490,11 @@ fn test_supports_ticket_collection_interface() {
 
     assert(src5.supports_interface(IIP_TICKET_COLLECTION_ID), 'interface supported');
     assert(src5.supports_interface(IERC2981_ID), 'erc2981 supported');
+}
+
+#[test]
+fn test_supports_licensed_collection_interface() {
+    let collection = deploy_ticket_collection();
+    let src5 = ISRC5Dispatcher { contract_address: collection.contract_address };
+    assert(src5.supports_interface(ILICENSED_COLLECTION_ID), 'licensed marker missing');
 }

--- a/contracts/IP-Tickets/tests/test_ipticket_collection.cairo
+++ b/contracts/IP-Tickets/tests/test_ipticket_collection.cairo
@@ -202,7 +202,7 @@ fn test_mint_free_ticket() {
     let token_id = ticket_collection.mint_ticket(collection_id);
 
     assert(token_id == 1, 'token id should be one');
-    assert(ticket_collection.total_supply() == 1, 'total supply should be one');
+    assert(ticket_collection.total_minted() == 1, 'total minted should be one');
     assert(ticket_collection.has_valid_ticket(receiver, collection_id), 'receiver should be valid');
     assert(
         ticket_collection.get_active_ticket_balance(receiver, collection_id) == 1, 'active balance',

--- a/contracts/IP-Tickets/tests/test_ipticket_collection.cairo
+++ b/contracts/IP-Tickets/tests/test_ipticket_collection.cairo
@@ -1,3 +1,4 @@
+use ip_ticket::IPTicketCollection::IPTicketCollection::{Event, TicketMinted};
 use ip_ticket::interface::{
     IIPTicketCollectionDispatcher, IIPTicketCollectionDispatcherTrait, IIP_TICKET_COLLECTION_ID,
     ILICENSED_COLLECTION_ID,
@@ -12,8 +13,8 @@ use openzeppelin_token::erc721::interface::{
 };
 use openzeppelin_utils::serde::SerializedAppend;
 use snforge_std::{
-    CheatSpan, ContractClassTrait, DeclareResultTrait, cheat_block_timestamp, cheat_caller_address,
-    declare,
+    CheatSpan, ContractClassTrait, DeclareResultTrait, EventSpyAssertionsTrait,
+    cheat_block_timestamp, cheat_caller_address, declare, spy_events,
 };
 use starknet::ContractAddress;
 
@@ -514,6 +515,7 @@ fn test_mint_ticket_to_recipient_other_than_payer() {
 
     cheat_block_timestamp(ticket_collection.contract_address, 1_000, CheatSpan::TargetCalls(1));
     cheat_caller_address(ticket_collection.contract_address, payer, CheatSpan::TargetCalls(1));
+    let mut spy = spy_events();
     let token_id = ticket_collection.mint_ticket(collection_id, recipient);
 
     let erc721 = IERC721Dispatcher { contract_address: ticket_collection.contract_address };
@@ -526,4 +528,18 @@ fn test_mint_ticket_to_recipient_other_than_payer() {
         ticket_collection.get_active_ticket_balance(payer, collection_id) == 0,
         'payer holds nothing',
     );
+
+    spy
+        .assert_emitted(
+            @array![
+                (
+                    ticket_collection.contract_address,
+                    Event::TicketMinted(
+                        TicketMinted {
+                            token_id, collection_id, owner: recipient, payer, minted_at: 1_000,
+                        },
+                    ),
+                ),
+            ],
+        );
 }

--- a/contracts/IP-Tickets/tests/test_ipticket_collection.cairo
+++ b/contracts/IP-Tickets/tests/test_ipticket_collection.cairo
@@ -199,7 +199,7 @@ fn test_mint_free_ticket() {
 
     cheat_block_timestamp(ticket_collection.contract_address, 1_000, CheatSpan::TargetCalls(1));
     cheat_caller_address(ticket_collection.contract_address, receiver, CheatSpan::TargetCalls(1));
-    let token_id = ticket_collection.mint_ticket(collection_id);
+    let token_id = ticket_collection.mint_ticket(collection_id, receiver);
 
     assert(token_id == 1, 'token id should be one');
     assert(ticket_collection.total_minted() == 1, 'total minted should be one');
@@ -234,7 +234,7 @@ fn test_paid_ticket_transfers_tokens() {
     erc20.approve(ticket_collection.contract_address, 1000);
 
     cheat_caller_address(ticket_collection.contract_address, receiver, CheatSpan::TargetCalls(1));
-    ticket_collection.mint_ticket(collection_id);
+    ticket_collection.mint_ticket(collection_id, receiver);
 
     assert(erc20.balance_of(CREATOR()) == 1000, 'creator should be paid');
     assert(erc20.balance_of(receiver) == 2000, 'buyer should pay');
@@ -251,10 +251,10 @@ fn test_mint_ticket_rejects_over_supply() {
         .create_ticket_collection(0, 1, 10_000, 0, Option::None, IPFS_URI());
 
     cheat_caller_address(ticket_collection.contract_address, receiver, CheatSpan::TargetCalls(1));
-    ticket_collection.mint_ticket(collection_id);
+    ticket_collection.mint_ticket(collection_id, receiver);
 
     cheat_caller_address(ticket_collection.contract_address, receiver, CheatSpan::TargetCalls(1));
-    ticket_collection.mint_ticket(collection_id);
+    ticket_collection.mint_ticket(collection_id, receiver);
 }
 
 #[test]
@@ -266,7 +266,7 @@ fn test_mint_ticket_rejects_expired_collection() {
 
     cheat_block_timestamp(ticket_collection.contract_address, 10_000, CheatSpan::TargetCalls(1));
     cheat_caller_address(ticket_collection.contract_address, receiver, CheatSpan::TargetCalls(1));
-    ticket_collection.mint_ticket(collection_id);
+    ticket_collection.mint_ticket(collection_id, receiver);
 }
 
 #[test]
@@ -280,7 +280,7 @@ fn test_mint_to_non_receiver_rejected() {
         ticket_collection.contract_address,
         CheatSpan::TargetCalls(1),
     );
-    ticket_collection.mint_ticket(collection_id);
+    ticket_collection.mint_ticket(collection_id, ticket_collection.contract_address);
 }
 
 #[test]
@@ -291,7 +291,7 @@ fn test_transfer_moves_access() {
     let collection_id = create_free_collection(ticket_collection, 10_000);
 
     cheat_caller_address(ticket_collection.contract_address, receiver_1, CheatSpan::TargetCalls(1));
-    let token_id = ticket_collection.mint_ticket(collection_id);
+    let token_id = ticket_collection.mint_ticket(collection_id, receiver_1);
 
     let erc721 = IERC721Dispatcher { contract_address: ticket_collection.contract_address };
     cheat_caller_address(ticket_collection.contract_address, receiver_1, CheatSpan::TargetCalls(1));
@@ -319,7 +319,7 @@ fn test_redeem_ticket_removes_access() {
     let collection_id = create_free_collection(ticket_collection, 10_000);
 
     cheat_caller_address(ticket_collection.contract_address, receiver, CheatSpan::TargetCalls(1));
-    let token_id = ticket_collection.mint_ticket(collection_id);
+    let token_id = ticket_collection.mint_ticket(collection_id, receiver);
 
     cheat_caller_address(ticket_collection.contract_address, receiver, CheatSpan::TargetCalls(1));
     ticket_collection.redeem_ticket(token_id);
@@ -338,7 +338,7 @@ fn test_cannot_redeem_twice() {
     let collection_id = create_free_collection(ticket_collection, 10_000);
 
     cheat_caller_address(ticket_collection.contract_address, receiver, CheatSpan::TargetCalls(1));
-    let token_id = ticket_collection.mint_ticket(collection_id);
+    let token_id = ticket_collection.mint_ticket(collection_id, receiver);
 
     cheat_caller_address(ticket_collection.contract_address, receiver, CheatSpan::TargetCalls(1));
     ticket_collection.redeem_ticket(token_id);
@@ -354,7 +354,7 @@ fn test_royalty_info() {
     let collection_id = create_free_collection(ticket_collection, 10_000);
 
     cheat_caller_address(ticket_collection.contract_address, receiver, CheatSpan::TargetCalls(1));
-    let token_id = ticket_collection.mint_ticket(collection_id);
+    let token_id = ticket_collection.mint_ticket(collection_id, receiver);
 
     let (recipient, amount) = ticket_collection.royaltyInfo(token_id, 1000);
     assert(recipient == CREATOR(), 'royalty recipient');
@@ -389,7 +389,7 @@ fn test_reentrant_payment_token_reverts_atomically() {
     assert(collection_id == expected_collection_id, 'expected first collection');
 
     cheat_caller_address(ticket_collection.contract_address, USER1(), CheatSpan::TargetCalls(1));
-    ticket_collection.mint_ticket(collection_id);
+    ticket_collection.mint_ticket(collection_id, USER1());
 }
 
 #[test]
@@ -422,7 +422,7 @@ fn test_deactivation_blocks_mint() {
     ticket_collection.set_collection_active(collection_id, false);
 
     cheat_caller_address(ticket_collection.contract_address, receiver, CheatSpan::TargetCalls(1));
-    ticket_collection.mint_ticket(collection_id);
+    ticket_collection.mint_ticket(collection_id, receiver);
 }
 
 #[test]
@@ -433,7 +433,7 @@ fn test_deactivation_preserves_existing_tickets() {
     let collection_id = create_free_collection(ticket_collection, 10_000);
 
     cheat_caller_address(ticket_collection.contract_address, receiver_1, CheatSpan::TargetCalls(1));
-    let token_id = ticket_collection.mint_ticket(collection_id);
+    let token_id = ticket_collection.mint_ticket(collection_id, receiver_1);
 
     cheat_caller_address(ticket_collection.contract_address, CREATOR(), CheatSpan::TargetCalls(1));
     ticket_collection.set_collection_active(collection_id, false);
@@ -465,7 +465,7 @@ fn test_reactivation_allows_mint() {
     ticket_collection.set_collection_active(collection_id, true);
 
     cheat_caller_address(ticket_collection.contract_address, receiver, CheatSpan::TargetCalls(1));
-    ticket_collection.mint_ticket(collection_id);
+    ticket_collection.mint_ticket(collection_id, receiver);
     assert(ticket_collection.has_valid_ticket(receiver, collection_id), 'mint should work again');
 }
 
@@ -476,7 +476,7 @@ fn test_royalty_info_snake_case() {
     let collection_id = create_free_collection(ticket_collection, 10_000);
 
     cheat_caller_address(ticket_collection.contract_address, receiver, CheatSpan::TargetCalls(1));
-    let token_id = ticket_collection.mint_ticket(collection_id);
+    let token_id = ticket_collection.mint_ticket(collection_id, receiver);
 
     let (recipient, amount) = ticket_collection.royalty_info(token_id, 1000);
     assert(recipient == CREATOR(), 'royalty recipient');
@@ -497,4 +497,33 @@ fn test_supports_licensed_collection_interface() {
     let collection = deploy_ticket_collection();
     let src5 = ISRC5Dispatcher { contract_address: collection.contract_address };
     assert(src5.supports_interface(ILICENSED_COLLECTION_ID), 'licensed marker missing');
+}
+
+#[test]
+fn test_collection_version() {
+    let collection = deploy_ticket_collection();
+    assert_eq!(collection.version(), "2.0.0");
+}
+
+#[test]
+fn test_mint_ticket_to_recipient_other_than_payer() {
+    let ticket_collection = deploy_ticket_collection();
+    let payer = USER1();
+    let recipient = deploy_receiver();
+    let collection_id = create_free_collection(ticket_collection, 10_000);
+
+    cheat_block_timestamp(ticket_collection.contract_address, 1_000, CheatSpan::TargetCalls(1));
+    cheat_caller_address(ticket_collection.contract_address, payer, CheatSpan::TargetCalls(1));
+    let token_id = ticket_collection.mint_ticket(collection_id, recipient);
+
+    let erc721 = IERC721Dispatcher { contract_address: ticket_collection.contract_address };
+    assert(erc721.owner_of(token_id) == recipient, 'recipient should own ticket');
+    assert(
+        ticket_collection.get_active_ticket_balance(recipient, collection_id) == 1,
+        'recipient active balance',
+    );
+    assert(
+        ticket_collection.get_active_ticket_balance(payer, collection_id) == 0,
+        'payer holds nothing',
+    );
 }

--- a/contracts/IP-Tickets/tests/test_ipticket_collection_factory.cairo
+++ b/contracts/IP-Tickets/tests/test_ipticket_collection_factory.cairo
@@ -2,7 +2,9 @@ use ip_ticket::IPTicketCollectionFactory::IPTicketCollectionFactory::{Collection
 use ip_ticket::interface::{
     IIPTicketCollectionDispatcher, IIPTicketCollectionDispatcherTrait,
     IIPTicketCollectionFactoryDispatcher, IIPTicketCollectionFactoryDispatcherTrait,
+    IIP_TICKET_COLLECTION_FACTORY_ID,
 };
+use openzeppelin_introspection::interface::{ISRC5Dispatcher, ISRC5DispatcherTrait};
 use openzeppelin_access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
 use openzeppelin_token::erc721::interface::{
     IERC721MetadataDispatcher, IERC721MetadataDispatcherTrait,
@@ -59,7 +61,7 @@ fn test_factory_constructor_class_hash() {
 #[test]
 fn test_factory_version() {
     let (factory, _) = deploy_factory();
-    assert_eq!(factory.version(), "1.0.0");
+    assert_eq!(factory.version(), "2.0.0");
 }
 
 #[test]
@@ -204,4 +206,11 @@ fn test_any_address_can_deploy_ticket_collection() {
     assert!(addr1.into() != 0_felt252);
     assert!(addr2.into() != 0_felt252);
     assert!(addr1 != addr2);
+}
+
+#[test]
+fn test_factory_registers_src5_discovery_id() {
+    let (_, factory_address) = deploy_factory();
+    let src5 = ISRC5Dispatcher { contract_address: factory_address };
+    assert(src5.supports_interface(IIP_TICKET_COLLECTION_FACTORY_ID), 'factory id missing');
 }

--- a/contracts/IP-Tickets/tests/test_ipticket_collection_factory.cairo
+++ b/contracts/IP-Tickets/tests/test_ipticket_collection_factory.cairo
@@ -4,8 +4,8 @@ use ip_ticket::interface::{
     IIPTicketCollectionFactoryDispatcher, IIPTicketCollectionFactoryDispatcherTrait,
     IIP_TICKET_COLLECTION_FACTORY_ID,
 };
-use openzeppelin_introspection::interface::{ISRC5Dispatcher, ISRC5DispatcherTrait};
 use openzeppelin_access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
+use openzeppelin_introspection::interface::{ISRC5Dispatcher, ISRC5DispatcherTrait};
 use openzeppelin_token::erc721::interface::{
     IERC721MetadataDispatcher, IERC721MetadataDispatcherTrait,
 };


### PR DESCRIPTION
## Summary
- Registers the `ILICENSED_COLLECTION_ID` SRC5 discovery marker (declares that a collection's metadata JSON follows the Mediolano programmable-license trait schema — discovery only, license stays soft-enforced data in metadata)
- Renames `total_supply()` → `total_minted()` (it was always a monotonic mint count — no burn path exists — the old name was misleading)
- Fixes the factory: it declared `IIP_TICKET_COLLECTION_FACTORY_ID` as SRC5-registered but never embedded SRC5 — now it actually does
- Adds `version()` views (`"2.0.0"`) to both the collection and factory, per the MIP protocol-versioning convention
- `mint_ticket` gains an explicit `recipient` parameter (caller still pays) — enables gifting a ticket or an agent purchasing on someone else's behalf in one transaction
- Bumps `IIP_TICKET_COLLECTION_ID` derivation to `mediolano.ip-ticket-collection.v2` — the ABI broke, and immutable v1 deployments keep registering the `.v1` ID, so consumers can distinguish the two ABIs via SRC5 alone
- `TicketMinted` event gains a `payer` field — with gifting, `owner` alone no longer identifies who paid
- Storage field `total_supply` renamed to `total_minted` to match the getter (fresh class, no layout concern)

No behavioral change to redemption, royalty computation, or the collectible-after-redemption trade path — all audit-confirmed correct and left untouched.

Design + audit: `medialane-core/docs/audits/2026-07-08-tickets-club-sponsorship-audit.md`, `medialane-core/docs/specs/2026-07-08-ip-tickets-license-redesign-design.md`

## Test plan
- [x] `scarb test` — 43/43 passing (39 baseline + 4 new)
- [x] `scarb fmt` clean
- [ ] Declare/deploy — separately authorized, not part of this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
