### PR TITLE
IP-ID v2: content-derived portable identity, relations, targeted attestations, commit-reveal

### DIFF
--- a/contracts/IP-ID/README.md
+++ b/contracts/IP-ID/README.md
@@ -10,11 +10,12 @@ The protocol is intentionally small, zero-fee, and append-only. It does not stor
 
 ## Principles
 
-- A work has one `ip_id`.
+- A work has one `ip_id`, and the `ip_id` is **content-derived**: `hash("IPID_WORK_V1", creator, metadata_hash, salt)`. Identity survives contract redeploy and chain re-anchoring — the registry state is a pure function of its event log, so replaying the log on a new anchor reconstructs the same works under the same IDs.
+- Two claimants of one content hash hold **parallel claims with distinct IDs**, not a first-come race for one ID. The contract records claims; it never adjudicates. Dispute resolution is deliberately platform-layer.
 - A work may have many chain-local representations.
 - Authorship and license claims live in immutable, content-addressed metadata.
-- New terms or metadata are represented by new work versions or new representations, not by mutating old claims.
-- Attestations are append-only claims, not privileged protocol truth.
+- New terms or metadata are represented by new works or new representations, not by mutating old claims. (The single exception: a sealed work's empty URI may be revealed once — the commitment hash never changes.)
+- Lineage, representation links, and attestations are all **append-only claims**, not privileged protocol truth.
 - Indexers and applications may project rich views from events, but the contract remains neutral.
 
 ## Core Model
@@ -23,14 +24,19 @@ The protocol is intentionally small, zero-fee, and append-only. It does not stor
 
 A `Work` is the canonical IP-ID record:
 
-- `creator`: the wallet that registered the work.
-- `controller`: the wallet allowed to link representations or rotate control.
-- `metadata_uri`: immutable metadata pointer.
-- `metadata_hash`: content hash for the metadata document.
-- `parent_ip_id`: optional parent work for remix/version lineage.
-- `parent_relation`: `VERSION`, `DERIVATIVE`, or another canonical relation used by the SDK/indexer.
-- `representation_count`: number of linked chain-local representations.
-- `attestation_count`: number of append-only attestations.
+- `creator`: the wallet that registered the work (part of the `ip_id` derivation).
+- `controller`: the wallet allowed to link representations, assert relations, reveal, or rotate control.
+- `metadata_uri`: immutable metadata pointer — empty for a sealed registration until revealed.
+- `metadata_hash`: content hash for the metadata document; the commitment for sealed works.
+- `representation_count` / `relation_count` / `attestation_count`: enumeration counters.
+
+### Relation
+
+A `Relation` is an append-only lineage claim asserted by the subject work's controller:
+
+- `relation_key`: `hash("IPID_RELATION_V1", ip_id, related_ip_id, relation_type)` — derived by the contract, globally unique, duplicate assertions revert.
+- `relation_type`: `VERSION`, `DERIVATIVE`, or another canonical relation interpreted by the SDK/indexer.
+- Multi-parent by construction: a remix of N works is N relations. Self-relations are rejected; both works must exist.
 
 ### Representation
 
@@ -52,15 +58,14 @@ hash("IPID_REPRESENTATION_V1", chain_id, asset_locator, token_id, content_id, st
 
 This prevents two clients from linking the same representation under different keys.
 
+**Representation links are claim-grade, not authoritative.** The contract cannot verify another chain. A link is the controller's claim; the asset's actual holder on the other chain can `CONFIRM` it (dual-consent, strong signal) or `DISPUTE` it via an attestation targeting the `representation_key`.
+
 ### Attestation
 
-An `Attestation` is an append-only claim about a work:
+An `Attestation` is an append-only claim about a work or about one of its claims:
 
-- provenance proof
-- creator signature proof
-- external registry proof
-- verification proof
-- legal/documentation proof
+- `subject_key = 0`: the attestation is about the work itself.
+- `subject_key = <representation_key | relation_key>`: the attestation targets that specific claim of the same work.
 
 The contract records the claim; it does not make the claim universally authoritative.
 
@@ -71,24 +76,44 @@ Canonical attestation type names exported by the contract:
 - `EXTERNAL_REGISTRY`
 - `LEGAL_PROOF`
 - `VERIFICATION`
+- `CONFIRM` — agreement with the targeted claim (e.g. the other-chain holder consents to a representation link)
+- `DISPUTE` — visible disagreement with the targeted claim
+- `ANCHOR` — reserved: "this state/work was anchored on chain X at height N" (Bitcoin proof-of-existence; no contract logic reads it yet)
+
+## Sealed registration (commit-then-reveal)
+
+Registering with an empty `metadata_uri` is a first-class sealed registration: the `metadata_hash` is the commitment and `created_at` is the proof-of-existence timestamp — proof a work existed at time T without disclosing it (unpublished manuscripts, priority evidence, embargoed drops).
+
+`reveal(ip_id, metadata_uri)` is controller-only and one-time (allowed only while the stored URI is empty). Verifying that the revealed content hashes to the commitment is an off-chain/SDK concern: the URI is a pointer; the chain proves the commitment and the reveal time.
 
 ## Interface
 
-- `register_work(metadata_uri, metadata_hash, parent_ip_id, parent_relation) -> ip_id`
+- `register_work(metadata_uri, metadata_hash, salt) -> ip_id`
+- `reveal(ip_id, metadata_uri)`
 - `link_representation(ip_id, chain_id, asset_locator, token_id, content_id, metadata_uri, metadata_hash, standard)`
+- `relate(ip_id, related_ip_id, relation_type) -> relation_key`
+- `attest(ip_id, subject_key, attestation_type, data_hash, uri) -> attestation_id`
 - `transfer_controller(ip_id, new_controller)`
-- `attest(ip_id, attestation_type, data_hash, uri) -> attestation_id`
+- `derive_ip_id(creator, metadata_hash, salt) -> ip_id`
 - `derive_representation_key(chain_id, asset_locator, token_id, content_id, standard) -> representation_key`
-- read helpers for works, representations, reverse lookup, representation keys, and attestations
+- `derive_relation_key(ip_id, related_ip_id, relation_type) -> relation_key`
+- `registered_count() -> count`
+- read helpers for works, representations, relations, attestations, reverse lookups, and per-work key enumeration
+
+## Reserved seams (documented, not built)
+
+- **Signed registration** — creator signs, anyone submits, so authorship is not welded to the gas payer (gasless apps, agents registering on a creator's behalf). Deferred until a consuming app needs it.
+- **Canonical locator hashing** — the rule deriving `asset_locator` / `content_id` from identifiers longer than a felt (Ordinals, Arweave) lives in the SDK as the single domain-tagged codec per chain, so two clients cannot derive different locators for one asset.
 
 ## What This Contract Does Not Do
 
 - No ERC-721 identity carrier.
-- No mutable `update_metadata`.
+- No mutable `update_metadata` (reveal fills an empty URI once; it never rewrites one).
 - No mutable `update_licensing`.
 - No `can_use_commercially` or derivative permission gates.
 - No admin verification flag.
 - No owner portfolio indexing in contract storage.
+- No dispute adjudication — the contract records `CONFIRM`/`DISPUTE`; interpretation is platform-layer.
 - No Medialane fee or governance coupling.
 
 Those belong in immutable metadata, optional service contracts, indexers, SDKs, or application policy.

--- a/contracts/IP-ID/Scarb.lock
+++ b/contracts/IP-ID/Scarb.lock
@@ -3,7 +3,7 @@ version = 1
 
 [[package]]
 name = "ip_id"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "snforge_std",
 ]

--- a/contracts/IP-ID/Scarb.toml
+++ b/contracts/IP-ID/Scarb.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ip_id"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024_07"
 
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html

--- a/contracts/IP-ID/src/IPIdentity.cairo
+++ b/contracts/IP-ID/src/IPIdentity.cairo
@@ -7,6 +7,8 @@ pub const ATTESTATION_CREATOR_SIGNATURE: felt252 = 'CREATOR_SIGNATURE';
 pub const ATTESTATION_EXTERNAL_REGISTRY: felt252 = 'EXTERNAL_REGISTRY';
 pub const ATTESTATION_LEGAL_PROOF: felt252 = 'LEGAL_PROOF';
 pub const ATTESTATION_VERIFICATION: felt252 = 'VERIFICATION';
+pub const ATTESTATION_CONFIRM: felt252 = 'CONFIRM';
+pub const ATTESTATION_DISPUTE: felt252 = 'DISPUTE';
 
 #[derive(Drop, Serde, starknet::Store, Clone)]
 pub struct Work {
@@ -50,6 +52,7 @@ pub struct Relation {
 pub struct Attestation {
     pub ip_id: felt252,
     pub attestation_id: u256,
+    pub subject_key: felt252,
     pub attester: ContractAddress,
     pub attestation_type: felt252,
     pub data_hash: felt252,
@@ -82,6 +85,7 @@ pub trait IIPIdentity<TContractState> {
     fn attest(
         ref self: TContractState,
         ip_id: felt252,
+        subject_key: felt252,
         attestation_type: felt252,
         data_hash: felt252,
         uri: ByteArray,
@@ -142,6 +146,7 @@ pub mod IPIdentity {
     const ERROR_INVALID_RELATION: felt252 = 'IPID: invalid relation';
     const ERROR_RELATION_ASSERTED: felt252 = 'IPID: relation asserted';
     const ERROR_SELF_RELATION: felt252 = 'IPID: self relation';
+    const ERROR_INVALID_SUBJECT: felt252 = 'IPID: invalid subject';
 
     #[storage]
     struct Storage {
@@ -221,6 +226,7 @@ pub mod IPIdentity {
         #[key]
         pub ip_id: felt252,
         pub attestation_id: u256,
+        pub subject_key: felt252,
         pub attester: ContractAddress,
         pub attestation_type: felt252,
         pub data_hash: felt252,
@@ -411,6 +417,7 @@ pub mod IPIdentity {
         fn attest(
             ref self: ContractState,
             ip_id: felt252,
+            subject_key: felt252,
             attestation_type: felt252,
             data_hash: felt252,
             uri: ByteArray,
@@ -420,12 +427,25 @@ pub mod IPIdentity {
             assert(attestation_type != 0, ERROR_INVALID_ATTESTATION);
             assert(data_hash != 0, ERROR_INVALID_ATTESTATION);
 
+            if subject_key != 0 {
+                let subject_owner = if self
+                    .representation_to_ip_id
+                    .read(subject_key)
+                    .is_non_zero() {
+                    self.representation_to_ip_id.read(subject_key)
+                } else {
+                    self.relation_to_ip_id.read(subject_key)
+                };
+                assert(subject_owner == ip_id, ERROR_INVALID_SUBJECT);
+            }
+
             let attester = get_caller_address();
             let attestation_id = work.attestation_count + 1;
             let timestamp = get_block_timestamp();
             let attestation = Attestation {
                 ip_id,
                 attestation_id,
+                subject_key,
                 attester,
                 attestation_type,
                 data_hash,
@@ -444,6 +464,7 @@ pub mod IPIdentity {
                     WorkAttested {
                         ip_id,
                         attestation_id,
+                        subject_key,
                         attester,
                         attestation_type,
                         data_hash,

--- a/contracts/IP-ID/src/IPIdentity.cairo
+++ b/contracts/IP-ID/src/IPIdentity.cairo
@@ -16,6 +16,7 @@ pub struct Work {
     pub metadata_hash: felt252,
     pub created_at: u64,
     pub representation_count: u256,
+    pub relation_count: u256,
     pub attestation_count: u256,
     pub exists: bool,
 }
@@ -33,6 +34,16 @@ pub struct Representation {
     pub standard: felt252,
     pub linked_at: u64,
     pub linked_by: ContractAddress,
+}
+
+#[derive(Drop, Serde, starknet::Store, Clone)]
+pub struct Relation {
+    pub ip_id: felt252,
+    pub relation_key: felt252,
+    pub related_ip_id: felt252,
+    pub relation_type: felt252,
+    pub asserted_at: u64,
+    pub asserted_by: ContractAddress,
 }
 
 #[derive(Drop, Serde, starknet::Store, Clone)]
@@ -76,7 +87,18 @@ pub trait IIPIdentity<TContractState> {
         uri: ByteArray,
     ) -> u256;
 
+    fn relate(
+        ref self: TContractState, ip_id: felt252, related_ip_id: felt252, relation_type: felt252,
+    ) -> felt252;
+
     fn get_work(self: @TContractState, ip_id: felt252) -> Work;
+    fn get_relation(self: @TContractState, relation_key: felt252) -> Relation;
+    fn get_relation_ip_id(self: @TContractState, relation_key: felt252) -> felt252;
+    fn get_work_relation_key(self: @TContractState, ip_id: felt252, index: u256) -> felt252;
+    fn is_relation_asserted(self: @TContractState, relation_key: felt252) -> bool;
+    fn derive_relation_key(
+        self: @TContractState, ip_id: felt252, related_ip_id: felt252, relation_type: felt252,
+    ) -> felt252;
     fn get_representation(self: @TContractState, representation_key: felt252) -> Representation;
     fn get_attestation(self: @TContractState, ip_id: felt252, attestation_id: u256) -> Attestation;
     fn get_representation_ip_id(self: @TContractState, representation_key: felt252) -> felt252;
@@ -107,7 +129,7 @@ pub mod IPIdentity {
         StoragePointerWriteAccess,
     };
     use starknet::{ContractAddress, get_block_timestamp, get_caller_address};
-    use super::{Attestation, IIPIdentity, Representation, Work};
+    use super::{Attestation, IIPIdentity, Relation, Representation, Work};
 
     const ERROR_INVALID_WORK: felt252 = 'IPID: invalid work';
     const ERROR_NOT_CONTROLLER: felt252 = 'IPID: not controller';
@@ -117,6 +139,9 @@ pub mod IPIdentity {
     const ERROR_INVALID_CONTROLLER: felt252 = 'IPID: invalid controller';
     const ERROR_INVALID_ATTESTATION: felt252 = 'IPID: invalid attestation';
     const ERROR_INVALID_METADATA: felt252 = 'IPID: invalid metadata';
+    const ERROR_INVALID_RELATION: felt252 = 'IPID: invalid relation';
+    const ERROR_RELATION_ASSERTED: felt252 = 'IPID: relation asserted';
+    const ERROR_SELF_RELATION: felt252 = 'IPID: self relation';
 
     #[storage]
     struct Storage {
@@ -125,6 +150,9 @@ pub mod IPIdentity {
         representation_to_ip_id: Map<felt252, felt252>,
         representations: Map<felt252, Representation>,
         work_representations: Map<(felt252, u256), felt252>,
+        relation_to_ip_id: Map<felt252, felt252>,
+        relations: Map<felt252, Relation>,
+        work_relations: Map<(felt252, u256), felt252>,
         attestations: Map<(felt252, u256), Attestation>,
     }
 
@@ -133,6 +161,7 @@ pub mod IPIdentity {
     enum Event {
         WorkRegistered: WorkRegistered,
         RepresentationLinked: RepresentationLinked,
+        RelationAsserted: RelationAsserted,
         ControllerTransferred: ControllerTransferred,
         WorkAttested: WorkAttested,
     }
@@ -163,6 +192,18 @@ pub mod IPIdentity {
         pub metadata_hash: felt252,
         pub standard: felt252,
         pub linked_by: ContractAddress,
+        pub timestamp: u64,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    pub struct RelationAsserted {
+        #[key]
+        pub ip_id: felt252,
+        #[key]
+        pub relation_key: felt252,
+        pub related_ip_id: felt252,
+        pub relation_type: felt252,
+        pub asserted_by: ContractAddress,
         pub timestamp: u64,
     }
 
@@ -206,6 +247,7 @@ pub mod IPIdentity {
                 metadata_hash,
                 created_at: timestamp,
                 representation_count: 0,
+                relation_count: 0,
                 attestation_count: 0,
                 exists: true,
             };
@@ -293,6 +335,52 @@ pub mod IPIdentity {
                         timestamp,
                     },
                 );
+        }
+
+        fn relate(
+            ref self: ContractState, ip_id: felt252, related_ip_id: felt252, relation_type: felt252,
+        ) -> felt252 {
+            let mut work = self.works.read(ip_id);
+            assert(work.exists, ERROR_INVALID_WORK);
+
+            let caller = get_caller_address();
+            assert(caller == work.controller, ERROR_NOT_CONTROLLER);
+            assert(relation_type != 0, ERROR_INVALID_RELATION);
+            assert(ip_id != related_ip_id, ERROR_SELF_RELATION);
+            assert(self.works.read(related_ip_id).exists, ERROR_INVALID_WORK);
+
+            let relation_key = self.derive_relation_key(ip_id, related_ip_id, relation_type);
+            assert(self.relation_to_ip_id.read(relation_key).is_zero(), ERROR_RELATION_ASSERTED);
+
+            let timestamp = get_block_timestamp();
+            let relation = Relation {
+                ip_id,
+                relation_key,
+                related_ip_id,
+                relation_type,
+                asserted_at: timestamp,
+                asserted_by: caller,
+            };
+
+            self.relation_to_ip_id.write(relation_key, ip_id);
+            self.relations.write(relation_key, relation);
+            self.work_relations.write((ip_id, work.relation_count), relation_key);
+            work.relation_count += 1;
+            self.works.write(ip_id, work);
+
+            self
+                .emit(
+                    RelationAsserted {
+                        ip_id,
+                        relation_key,
+                        related_ip_id,
+                        relation_type,
+                        asserted_by: caller,
+                        timestamp,
+                    },
+                );
+
+            relation_key
         }
 
         fn transfer_controller(
@@ -391,6 +479,37 @@ pub mod IPIdentity {
                 ERROR_INVALID_ATTESTATION,
             );
             self.attestations.read((ip_id, attestation_id))
+        }
+
+        fn get_relation(self: @ContractState, relation_key: felt252) -> Relation {
+            assert(self.relation_to_ip_id.read(relation_key).is_non_zero(), ERROR_INVALID_RELATION);
+            self.relations.read(relation_key)
+        }
+
+        fn get_relation_ip_id(self: @ContractState, relation_key: felt252) -> felt252 {
+            self.relation_to_ip_id.read(relation_key)
+        }
+
+        fn get_work_relation_key(self: @ContractState, ip_id: felt252, index: u256) -> felt252 {
+            let work = self.works.read(ip_id);
+            assert(work.exists, ERROR_INVALID_WORK);
+            assert(index < work.relation_count, ERROR_INVALID_RELATION);
+            self.work_relations.read((ip_id, index))
+        }
+
+        fn is_relation_asserted(self: @ContractState, relation_key: felt252) -> bool {
+            self.relation_to_ip_id.read(relation_key).is_non_zero()
+        }
+
+        fn derive_relation_key(
+            self: @ContractState, ip_id: felt252, related_ip_id: felt252, relation_type: felt252,
+        ) -> felt252 {
+            PoseidonTrait::new()
+                .update_with('IPID_RELATION_V1')
+                .update_with(ip_id)
+                .update_with(related_ip_id)
+                .update_with(relation_type)
+                .finalize()
         }
 
         fn get_representation_ip_id(self: @ContractState, representation_key: felt252) -> felt252 {

--- a/contracts/IP-ID/src/IPIdentity.cairo
+++ b/contracts/IP-ID/src/IPIdentity.cairo
@@ -66,6 +66,8 @@ pub trait IIPIdentity<TContractState> {
         ref self: TContractState, metadata_uri: ByteArray, metadata_hash: felt252, salt: felt252,
     ) -> felt252;
 
+    fn reveal(ref self: TContractState, ip_id: felt252, metadata_uri: ByteArray);
+
     fn link_representation(
         ref self: TContractState,
         ip_id: felt252,
@@ -147,6 +149,7 @@ pub mod IPIdentity {
     const ERROR_RELATION_ASSERTED: felt252 = 'IPID: relation asserted';
     const ERROR_SELF_RELATION: felt252 = 'IPID: self relation';
     const ERROR_INVALID_SUBJECT: felt252 = 'IPID: invalid subject';
+    const ERROR_ALREADY_REVEALED: felt252 = 'IPID: already revealed';
 
     #[storage]
     struct Storage {
@@ -165,6 +168,7 @@ pub mod IPIdentity {
     #[derive(Drop, starknet::Event)]
     enum Event {
         WorkRegistered: WorkRegistered,
+        WorkRevealed: WorkRevealed,
         RepresentationLinked: RepresentationLinked,
         RelationAsserted: RelationAsserted,
         ControllerTransferred: ControllerTransferred,
@@ -180,6 +184,14 @@ pub mod IPIdentity {
         pub controller: ContractAddress,
         pub metadata_hash: felt252,
         pub salt: felt252,
+        pub metadata_uri: ByteArray,
+        pub timestamp: u64,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    pub struct WorkRevealed {
+        #[key]
+        pub ip_id: felt252,
         pub metadata_uri: ByteArray,
         pub timestamp: u64,
     }
@@ -275,6 +287,21 @@ pub mod IPIdentity {
                 );
 
             ip_id
+        }
+
+        fn reveal(ref self: ContractState, ip_id: felt252, metadata_uri: ByteArray) {
+            let mut work = self.works.read(ip_id);
+            assert(work.exists, ERROR_INVALID_WORK);
+
+            let caller = get_caller_address();
+            assert(caller == work.controller, ERROR_NOT_CONTROLLER);
+            assert(work.metadata_uri.len() == 0, ERROR_ALREADY_REVEALED);
+            assert(metadata_uri.len() != 0, ERROR_INVALID_METADATA);
+
+            work.metadata_uri = metadata_uri.clone();
+            self.works.write(ip_id, work);
+
+            self.emit(WorkRevealed { ip_id, metadata_uri, timestamp: get_block_timestamp() });
         }
 
         fn link_representation(

--- a/contracts/IP-ID/src/IPIdentity.cairo
+++ b/contracts/IP-ID/src/IPIdentity.cairo
@@ -9,8 +9,8 @@ pub const ATTESTATION_LEGAL_PROOF: felt252 = 'LEGAL_PROOF';
 pub const ATTESTATION_VERIFICATION: felt252 = 'VERIFICATION';
 pub const ATTESTATION_CONFIRM: felt252 = 'CONFIRM';
 pub const ATTESTATION_DISPUTE: felt252 = 'DISPUTE';
-// Reserved seam: "this state/work was anchored on chain X at height N"
-// (Bitcoin proof-of-existence, roadmap Horizon). No contract logic reads it.
+// Claims "this work/state was anchored on chain X at height N"
+// (proof-of-existence). No contract logic reads it.
 pub const ATTESTATION_ANCHOR: felt252 = 'ANCHOR';
 
 #[derive(Drop, Serde, starknet::Store, Clone)]

--- a/contracts/IP-ID/src/IPIdentity.cairo
+++ b/contracts/IP-ID/src/IPIdentity.cairo
@@ -14,8 +14,6 @@ pub struct Work {
     pub creator: ContractAddress,
     pub metadata_uri: ByteArray,
     pub metadata_hash: felt252,
-    pub parent_ip_id: u256,
-    pub parent_relation: felt252,
     pub created_at: u64,
     pub representation_count: u256,
     pub attestation_count: u256,
@@ -24,7 +22,7 @@ pub struct Work {
 
 #[derive(Drop, Serde, starknet::Store, Clone)]
 pub struct Representation {
-    pub ip_id: u256,
+    pub ip_id: felt252,
     pub chain_id: felt252,
     pub representation_key: felt252,
     pub asset_locator: felt252,
@@ -39,7 +37,7 @@ pub struct Representation {
 
 #[derive(Drop, Serde, starknet::Store, Clone)]
 pub struct Attestation {
-    pub ip_id: u256,
+    pub ip_id: felt252,
     pub attestation_id: u256,
     pub attester: ContractAddress,
     pub attestation_type: felt252,
@@ -51,16 +49,12 @@ pub struct Attestation {
 #[starknet::interface]
 pub trait IIPIdentity<TContractState> {
     fn register_work(
-        ref self: TContractState,
-        metadata_uri: ByteArray,
-        metadata_hash: felt252,
-        parent_ip_id: u256,
-        parent_relation: felt252,
-    ) -> u256;
+        ref self: TContractState, metadata_uri: ByteArray, metadata_hash: felt252, salt: felt252,
+    ) -> felt252;
 
     fn link_representation(
         ref self: TContractState,
-        ip_id: u256,
+        ip_id: felt252,
         chain_id: felt252,
         asset_locator: felt252,
         token_id: u256,
@@ -70,24 +64,29 @@ pub trait IIPIdentity<TContractState> {
         standard: felt252,
     );
 
-    fn transfer_controller(ref self: TContractState, ip_id: u256, new_controller: ContractAddress);
+    fn transfer_controller(
+        ref self: TContractState, ip_id: felt252, new_controller: ContractAddress,
+    );
 
     fn attest(
         ref self: TContractState,
-        ip_id: u256,
+        ip_id: felt252,
         attestation_type: felt252,
         data_hash: felt252,
         uri: ByteArray,
     ) -> u256;
 
-    fn get_work(self: @TContractState, ip_id: u256) -> Work;
+    fn get_work(self: @TContractState, ip_id: felt252) -> Work;
     fn get_representation(self: @TContractState, representation_key: felt252) -> Representation;
-    fn get_attestation(self: @TContractState, ip_id: u256, attestation_id: u256) -> Attestation;
-    fn get_representation_ip_id(self: @TContractState, representation_key: felt252) -> u256;
-    fn get_work_representation_key(self: @TContractState, ip_id: u256, index: u256) -> felt252;
-    fn is_work_registered(self: @TContractState, ip_id: u256) -> bool;
+    fn get_attestation(self: @TContractState, ip_id: felt252, attestation_id: u256) -> Attestation;
+    fn get_representation_ip_id(self: @TContractState, representation_key: felt252) -> felt252;
+    fn get_work_representation_key(self: @TContractState, ip_id: felt252, index: u256) -> felt252;
+    fn is_work_registered(self: @TContractState, ip_id: felt252) -> bool;
     fn is_representation_linked(self: @TContractState, representation_key: felt252) -> bool;
-    fn get_total_works(self: @TContractState) -> u256;
+    fn registered_count(self: @TContractState) -> u256;
+    fn derive_ip_id(
+        self: @TContractState, creator: ContractAddress, metadata_hash: felt252, salt: felt252,
+    ) -> felt252;
     fn derive_representation_key(
         self: @TContractState,
         chain_id: felt252,
@@ -112,7 +111,7 @@ pub mod IPIdentity {
 
     const ERROR_INVALID_WORK: felt252 = 'IPID: invalid work';
     const ERROR_NOT_CONTROLLER: felt252 = 'IPID: not controller';
-    const ERROR_INVALID_PARENT: felt252 = 'IPID: invalid parent';
+    const ERROR_ALREADY_REGISTERED: felt252 = 'IPID: already registered';
     const ERROR_REPRESENTATION_LINKED: felt252 = 'IPID: representation linked';
     const ERROR_INVALID_REPRESENTATION: felt252 = 'IPID: invalid representation';
     const ERROR_INVALID_CONTROLLER: felt252 = 'IPID: invalid controller';
@@ -121,12 +120,12 @@ pub mod IPIdentity {
 
     #[storage]
     struct Storage {
-        next_ip_id: u256,
-        works: Map<u256, Work>,
-        representation_to_ip_id: Map<felt252, u256>,
+        registered_count: u256,
+        works: Map<felt252, Work>,
+        representation_to_ip_id: Map<felt252, felt252>,
         representations: Map<felt252, Representation>,
-        work_representations: Map<(u256, u256), felt252>,
-        attestations: Map<(u256, u256), Attestation>,
+        work_representations: Map<(felt252, u256), felt252>,
+        attestations: Map<(felt252, u256), Attestation>,
     }
 
     #[event]
@@ -141,13 +140,12 @@ pub mod IPIdentity {
     #[derive(Drop, starknet::Event)]
     pub struct WorkRegistered {
         #[key]
-        pub ip_id: u256,
+        pub ip_id: felt252,
         #[key]
         pub creator: ContractAddress,
         pub controller: ContractAddress,
         pub metadata_hash: felt252,
-        pub parent_ip_id: u256,
-        pub parent_relation: felt252,
+        pub salt: felt252,
         pub metadata_uri: ByteArray,
         pub timestamp: u64,
     }
@@ -155,7 +153,7 @@ pub mod IPIdentity {
     #[derive(Drop, starknet::Event)]
     pub struct RepresentationLinked {
         #[key]
-        pub ip_id: u256,
+        pub ip_id: felt252,
         #[key]
         pub representation_key: felt252,
         pub chain_id: felt252,
@@ -171,7 +169,7 @@ pub mod IPIdentity {
     #[derive(Drop, starknet::Event)]
     pub struct ControllerTransferred {
         #[key]
-        pub ip_id: u256,
+        pub ip_id: felt252,
         pub previous_controller: ContractAddress,
         pub new_controller: ContractAddress,
         pub timestamp: u64,
@@ -180,7 +178,7 @@ pub mod IPIdentity {
     #[derive(Drop, starknet::Event)]
     pub struct WorkAttested {
         #[key]
-        pub ip_id: u256,
+        pub ip_id: felt252,
         pub attestation_id: u256,
         pub attester: ContractAddress,
         pub attestation_type: felt252,
@@ -192,33 +190,20 @@ pub mod IPIdentity {
     #[abi(embed_v0)]
     impl IPIdentityImpl of IIPIdentity<ContractState> {
         fn register_work(
-            ref self: ContractState,
-            metadata_uri: ByteArray,
-            metadata_hash: felt252,
-            parent_ip_id: u256,
-            parent_relation: felt252,
-        ) -> u256 {
+            ref self: ContractState, metadata_uri: ByteArray, metadata_hash: felt252, salt: felt252,
+        ) -> felt252 {
             assert(metadata_hash != 0, ERROR_INVALID_METADATA);
 
-            if parent_ip_id.is_non_zero() {
-                assert(self.works.read(parent_ip_id).exists, ERROR_INVALID_PARENT);
-                assert(parent_relation != 0, ERROR_INVALID_PARENT);
-            } else {
-                assert(parent_relation == 0, ERROR_INVALID_PARENT);
-            }
-
             let creator = get_caller_address();
-            let timestamp = get_block_timestamp();
-            let ip_id = self.next_ip_id.read() + 1;
-            self.next_ip_id.write(ip_id);
+            let ip_id = self.derive_ip_id(creator, metadata_hash, salt);
+            assert(!self.works.read(ip_id).exists, ERROR_ALREADY_REGISTERED);
 
+            let timestamp = get_block_timestamp();
             let work = Work {
                 controller: creator,
                 creator,
                 metadata_uri: metadata_uri.clone(),
                 metadata_hash,
-                parent_ip_id,
-                parent_relation,
                 created_at: timestamp,
                 representation_count: 0,
                 attestation_count: 0,
@@ -226,6 +211,7 @@ pub mod IPIdentity {
             };
 
             self.works.write(ip_id, work);
+            self.registered_count.write(self.registered_count.read() + 1);
 
             self
                 .emit(
@@ -234,8 +220,7 @@ pub mod IPIdentity {
                         creator,
                         controller: creator,
                         metadata_hash,
-                        parent_ip_id,
-                        parent_relation,
+                        salt,
                         metadata_uri,
                         timestamp,
                     },
@@ -246,7 +231,7 @@ pub mod IPIdentity {
 
         fn link_representation(
             ref self: ContractState,
-            ip_id: u256,
+            ip_id: felt252,
             chain_id: felt252,
             asset_locator: felt252,
             token_id: u256,
@@ -311,7 +296,7 @@ pub mod IPIdentity {
         }
 
         fn transfer_controller(
-            ref self: ContractState, ip_id: u256, new_controller: ContractAddress,
+            ref self: ContractState, ip_id: felt252, new_controller: ContractAddress,
         ) {
             let mut work = self.works.read(ip_id);
             assert(work.exists, ERROR_INVALID_WORK);
@@ -337,7 +322,7 @@ pub mod IPIdentity {
 
         fn attest(
             ref self: ContractState,
-            ip_id: u256,
+            ip_id: felt252,
             attestation_type: felt252,
             data_hash: felt252,
             uri: ByteArray,
@@ -382,7 +367,7 @@ pub mod IPIdentity {
             attestation_id
         }
 
-        fn get_work(self: @ContractState, ip_id: u256) -> Work {
+        fn get_work(self: @ContractState, ip_id: felt252) -> Work {
             let work = self.works.read(ip_id);
             assert(work.exists, ERROR_INVALID_WORK);
             work
@@ -397,7 +382,7 @@ pub mod IPIdentity {
         }
 
         fn get_attestation(
-            self: @ContractState, ip_id: u256, attestation_id: u256,
+            self: @ContractState, ip_id: felt252, attestation_id: u256,
         ) -> Attestation {
             let work = self.works.read(ip_id);
             assert(work.exists, ERROR_INVALID_WORK);
@@ -408,18 +393,20 @@ pub mod IPIdentity {
             self.attestations.read((ip_id, attestation_id))
         }
 
-        fn get_representation_ip_id(self: @ContractState, representation_key: felt252) -> u256 {
+        fn get_representation_ip_id(self: @ContractState, representation_key: felt252) -> felt252 {
             self.representation_to_ip_id.read(representation_key)
         }
 
-        fn get_work_representation_key(self: @ContractState, ip_id: u256, index: u256) -> felt252 {
+        fn get_work_representation_key(
+            self: @ContractState, ip_id: felt252, index: u256,
+        ) -> felt252 {
             let work = self.works.read(ip_id);
             assert(work.exists, ERROR_INVALID_WORK);
             assert(index < work.representation_count, ERROR_INVALID_REPRESENTATION);
             self.work_representations.read((ip_id, index))
         }
 
-        fn is_work_registered(self: @ContractState, ip_id: u256) -> bool {
+        fn is_work_registered(self: @ContractState, ip_id: felt252) -> bool {
             self.works.read(ip_id).exists
         }
 
@@ -427,8 +414,19 @@ pub mod IPIdentity {
             self.representation_to_ip_id.read(representation_key).is_non_zero()
         }
 
-        fn get_total_works(self: @ContractState) -> u256 {
-            self.next_ip_id.read()
+        fn registered_count(self: @ContractState) -> u256 {
+            self.registered_count.read()
+        }
+
+        fn derive_ip_id(
+            self: @ContractState, creator: ContractAddress, metadata_hash: felt252, salt: felt252,
+        ) -> felt252 {
+            PoseidonTrait::new()
+                .update_with('IPID_WORK_V1')
+                .update_with(creator)
+                .update_with(metadata_hash)
+                .update_with(salt)
+                .finalize()
         }
 
         fn derive_representation_key(

--- a/contracts/IP-ID/src/IPIdentity.cairo
+++ b/contracts/IP-ID/src/IPIdentity.cairo
@@ -9,6 +9,9 @@ pub const ATTESTATION_LEGAL_PROOF: felt252 = 'LEGAL_PROOF';
 pub const ATTESTATION_VERIFICATION: felt252 = 'VERIFICATION';
 pub const ATTESTATION_CONFIRM: felt252 = 'CONFIRM';
 pub const ATTESTATION_DISPUTE: felt252 = 'DISPUTE';
+// Reserved seam: "this state/work was anchored on chain X at height N"
+// (Bitcoin proof-of-existence, roadmap Horizon). No contract logic reads it.
+pub const ATTESTATION_ANCHOR: felt252 = 'ANCHOR';
 
 #[derive(Drop, Serde, starknet::Store, Clone)]
 pub struct Work {

--- a/contracts/IP-ID/tests/test_contract.cairo
+++ b/contracts/IP-ID/tests/test_contract.cairo
@@ -34,65 +34,83 @@ fn deploy_ip_identity() -> IIPIdentityDispatcher {
     IIPIdentityDispatcher { contract_address }
 }
 
+fn register_default_work(ip_identity: IIPIdentityDispatcher) -> felt252 {
+    cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(1));
+    ip_identity.register_work("ipfs://work", 'work_hash', 0)
+}
+
 #[test]
 fn test_register_work_creates_immutable_anchor() {
     let ip_identity = deploy_ip_identity();
 
     cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(1));
     start_cheat_block_timestamp(ip_identity.contract_address, 1000);
-    let ip_id = ip_identity.register_work("ipfs://work-metadata", 'metadata_hash', 0, 0);
+    let ip_id = ip_identity.register_work("ipfs://work-metadata", 'metadata_hash', 0);
     stop_cheat_block_timestamp(ip_identity.contract_address);
 
     let work = ip_identity.get_work(ip_id);
-    assert(ip_id == 1, 'wrong ip id');
+    let expected_id = ip_identity.derive_ip_id(creator(), 'metadata_hash', 0);
+    assert(ip_id == expected_id, 'id not content-derived');
     assert(work.creator == creator(), 'wrong creator');
     assert(work.controller == creator(), 'wrong controller');
     assert(work.metadata_uri == "ipfs://work-metadata", 'wrong uri');
     assert(work.metadata_hash == 'metadata_hash', 'wrong hash');
-    assert(work.parent_ip_id == 0, 'wrong parent');
-    assert(work.parent_relation == 0, 'wrong relation');
     assert(work.created_at == 1000, 'wrong timestamp');
     assert(work.representation_count == 0, 'wrong representations');
     assert(work.attestation_count == 0, 'wrong attestations');
-    assert(ip_identity.get_total_works() == 1, 'wrong total');
+    assert(ip_identity.registered_count() == 1, 'wrong count');
 }
 
 #[test]
-fn test_register_child_work_requires_existing_parent() {
+fn test_ip_id_is_deterministic_across_deployments() {
+    let first = deploy_ip_identity();
+    let second = deploy_ip_identity();
+
+    cheat_caller_address(first.contract_address, creator(), CheatSpan::TargetCalls(1));
+    let id_on_first = first.register_work("ipfs://work", 'work_hash', 7);
+
+    cheat_caller_address(second.contract_address, creator(), CheatSpan::TargetCalls(1));
+    let id_on_second = second.register_work("ipfs://work", 'work_hash', 7);
+
+    assert(id_on_first == id_on_second, 'id not portable');
+    assert(id_on_first == first.derive_ip_id(creator(), 'work_hash', 7), 'derive mismatch');
+}
+
+#[test]
+#[should_panic(expected: ('IPID: already registered',))]
+fn test_duplicate_registration_reverts() {
+    let ip_identity = deploy_ip_identity();
+
+    cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(2));
+    ip_identity.register_work("ipfs://work", 'work_hash', 0);
+    ip_identity.register_work("ipfs://work", 'work_hash', 0);
+}
+
+#[test]
+fn test_parallel_claims_on_same_hash_coexist() {
     let ip_identity = deploy_ip_identity();
 
     cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(1));
-    let parent_ip_id = ip_identity.register_work("ipfs://parent", 'parent_hash', 0, 0);
+    let first_claim = ip_identity.register_work("ipfs://work", 'contested_hash', 0);
 
     cheat_caller_address(ip_identity.contract_address, collaborator(), CheatSpan::TargetCalls(1));
-    let child_ip_id = ip_identity
-        .register_work("ipfs://child", 'child_hash', parent_ip_id, 'DERIVATIVE');
+    let second_claim = ip_identity.register_work("ipfs://copy", 'contested_hash', 0);
 
-    let child = ip_identity.get_work(child_ip_id);
-    assert(child.parent_ip_id == parent_ip_id, 'wrong parent link');
-    assert(child.parent_relation == 'DERIVATIVE', 'wrong parent relation');
-    assert(child.creator == collaborator(), 'wrong child creator');
+    assert(first_claim != second_claim, 'claims must be distinct');
+    assert(ip_identity.get_work(first_claim).creator == creator(), 'wrong first claimant');
+    assert(ip_identity.get_work(second_claim).creator == collaborator(), 'wrong second claimant');
+    assert(ip_identity.registered_count() == 2, 'wrong count');
 }
 
 #[test]
-#[should_panic(expected: ('IPID: invalid parent',))]
-fn test_register_child_work_rejects_missing_parent() {
+fn test_same_creator_distinct_salts_distinct_works() {
     let ip_identity = deploy_ip_identity();
 
-    cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(1));
-    ip_identity.register_work("ipfs://child", 'child_hash', 999, 'DERIVATIVE');
-}
+    cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(2));
+    let first = ip_identity.register_work("ipfs://work", 'work_hash', 1);
+    let second = ip_identity.register_work("ipfs://work", 'work_hash', 2);
 
-#[test]
-#[should_panic(expected: ('IPID: invalid parent',))]
-fn test_child_work_requires_parent_relation() {
-    let ip_identity = deploy_ip_identity();
-
-    cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(1));
-    let parent_ip_id = ip_identity.register_work("ipfs://parent", 'parent_hash', 0, 0);
-
-    cheat_caller_address(ip_identity.contract_address, collaborator(), CheatSpan::TargetCalls(1));
-    ip_identity.register_work("ipfs://child", 'child_hash', parent_ip_id, 0);
+    assert(first != second, 'salts must separate ids');
 }
 
 #[test]
@@ -101,15 +119,13 @@ fn test_register_work_requires_metadata_hash() {
     let ip_identity = deploy_ip_identity();
 
     cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(1));
-    ip_identity.register_work("ipfs://work", 0, 0, 0);
+    ip_identity.register_work("ipfs://work", 0, 0);
 }
 
 #[test]
 fn test_controller_links_multiple_representations() {
     let ip_identity = deploy_ip_identity();
-
-    cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(1));
-    let ip_id = ip_identity.register_work("ipfs://work", 'work_hash', 0, 0);
+    let ip_id = register_default_work(ip_identity);
     let starknet_key = ip_identity
         .derive_representation_key('starknet', asset_locator(), 7, 0, 'ERC721');
     let ethereum_key = ip_identity
@@ -161,9 +177,7 @@ fn test_controller_links_multiple_representations() {
 #[should_panic(expected: ('IPID: invalid representation',))]
 fn test_representation_requires_chain_namespace() {
     let ip_identity = deploy_ip_identity();
-
-    cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(1));
-    let ip_id = ip_identity.register_work("ipfs://work", 'work_hash', 0, 0);
+    let ip_id = register_default_work(ip_identity);
 
     cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(1));
     ip_identity
@@ -183,9 +197,7 @@ fn test_representation_requires_chain_namespace() {
 #[should_panic(expected: ('IPID: not controller',))]
 fn test_only_controller_can_link_representation() {
     let ip_identity = deploy_ip_identity();
-
-    cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(1));
-    let ip_id = ip_identity.register_work("ipfs://work", 'work_hash', 0, 0);
+    let ip_id = register_default_work(ip_identity);
 
     cheat_caller_address(ip_identity.contract_address, collaborator(), CheatSpan::TargetCalls(1));
     ip_identity
@@ -207,10 +219,10 @@ fn test_representation_key_is_globally_unique() {
     let ip_identity = deploy_ip_identity();
 
     cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(1));
-    let first_ip_id = ip_identity.register_work("ipfs://work-1", 'work_hash_1', 0, 0);
+    let first_ip_id = ip_identity.register_work("ipfs://work-1", 'work_hash_1', 0);
 
     cheat_caller_address(ip_identity.contract_address, collaborator(), CheatSpan::TargetCalls(1));
-    let second_ip_id = ip_identity.register_work("ipfs://work-2", 'work_hash_2', 0, 0);
+    let second_ip_id = ip_identity.register_work("ipfs://work-2", 'work_hash_2', 0);
 
     cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(1));
     ip_identity
@@ -242,9 +254,7 @@ fn test_representation_key_is_globally_unique() {
 #[test]
 fn test_controller_can_be_transferred() {
     let ip_identity = deploy_ip_identity();
-
-    cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(1));
-    let ip_id = ip_identity.register_work("ipfs://work", 'work_hash', 0, 0);
+    let ip_id = register_default_work(ip_identity);
 
     cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(1));
     ip_identity.transfer_controller(ip_id, new_controller());
@@ -275,46 +285,8 @@ fn test_controller_can_be_transferred() {
 #[should_panic(expected: ('IPID: invalid controller',))]
 fn test_controller_transfer_rejects_zero_address() {
     let ip_identity = deploy_ip_identity();
-
-    cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(1));
-    let ip_id = ip_identity.register_work("ipfs://work", 'work_hash', 0, 0);
+    let ip_id = register_default_work(ip_identity);
 
     cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(1));
     ip_identity.transfer_controller(ip_id, zero_address());
-}
-
-#[test]
-fn test_anyone_can_add_append_only_attestation() {
-    let ip_identity = deploy_ip_identity();
-
-    cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(1));
-    let ip_id = ip_identity.register_work("ipfs://work", 'work_hash', 0, 0);
-
-    cheat_caller_address(ip_identity.contract_address, collaborator(), CheatSpan::TargetCalls(1));
-    start_cheat_block_timestamp(ip_identity.contract_address, 3000);
-    let attestation_id = ip_identity
-        .attest(ip_id, 'PROVENANCE', 'provenance_hash', "ipfs://provenance-proof");
-    stop_cheat_block_timestamp(ip_identity.contract_address);
-
-    let work = ip_identity.get_work(ip_id);
-    let attestation = ip_identity.get_attestation(ip_id, attestation_id);
-    assert(attestation_id == 1, 'wrong attestation id');
-    assert(work.attestation_count == 1, 'wrong attestation count');
-    assert(attestation.attester == collaborator(), 'wrong attester');
-    assert(attestation.attestation_type == 'PROVENANCE', 'wrong type');
-    assert(attestation.data_hash == 'provenance_hash', 'wrong data hash');
-    assert(attestation.uri == "ipfs://provenance-proof", 'wrong uri');
-    assert(attestation.created_at == 3000, 'wrong attestation timestamp');
-}
-
-#[test]
-#[should_panic(expected: ('IPID: invalid attestation',))]
-fn test_attestation_requires_type_and_hash() {
-    let ip_identity = deploy_ip_identity();
-
-    cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(1));
-    let ip_id = ip_identity.register_work("ipfs://work", 'work_hash', 0, 0);
-
-    cheat_caller_address(ip_identity.contract_address, collaborator(), CheatSpan::TargetCalls(1));
-    ip_identity.attest(ip_id, 0, 'provenance_hash', "ipfs://provenance-proof");
 }

--- a/contracts/IP-ID/tests/test_contract.cairo
+++ b/contracts/IP-ID/tests/test_contract.cairo
@@ -483,3 +483,69 @@ fn test_attestation_rejects_other_works_subject() {
     cheat_caller_address(ip_identity.contract_address, collaborator(), CheatSpan::TargetCalls(1));
     ip_identity.attest(ip_id, foreign_key, 'CONFIRM', 'hash', "ipfs://proof");
 }
+
+#[test]
+fn test_sealed_registration_then_reveal() {
+    let ip_identity = deploy_ip_identity();
+
+    cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(1));
+    start_cheat_block_timestamp(ip_identity.contract_address, 5000);
+    let ip_id = ip_identity.register_work("", 'sealed_hash', 0);
+    stop_cheat_block_timestamp(ip_identity.contract_address);
+
+    let sealed = ip_identity.get_work(ip_id);
+    assert(sealed.metadata_uri == "", 'should be sealed');
+    assert(sealed.metadata_hash == 'sealed_hash', 'commitment missing');
+    assert(sealed.created_at == 5000, 'wrong existence timestamp');
+
+    cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(1));
+    ip_identity.reveal(ip_id, "ipfs://revealed-manuscript");
+
+    let revealed = ip_identity.get_work(ip_id);
+    assert(revealed.metadata_uri == "ipfs://revealed-manuscript", 'reveal did not stick');
+    assert(revealed.metadata_hash == 'sealed_hash', 'commitment changed');
+    assert(revealed.created_at == 5000, 'timestamp changed');
+}
+
+#[test]
+#[should_panic(expected: ('IPID: already revealed',))]
+fn test_reveal_is_one_time() {
+    let ip_identity = deploy_ip_identity();
+
+    cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(3));
+    let ip_id = ip_identity.register_work("", 'sealed_hash', 0);
+    ip_identity.reveal(ip_id, "ipfs://first-reveal");
+    ip_identity.reveal(ip_id, "ipfs://second-reveal");
+}
+
+#[test]
+#[should_panic(expected: ('IPID: already revealed',))]
+fn test_reveal_rejects_unsealed_work() {
+    let ip_identity = deploy_ip_identity();
+    let ip_id = register_default_work(ip_identity);
+
+    cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(1));
+    ip_identity.reveal(ip_id, "ipfs://overwrite-attempt");
+}
+
+#[test]
+#[should_panic(expected: ('IPID: not controller',))]
+fn test_only_controller_reveals() {
+    let ip_identity = deploy_ip_identity();
+
+    cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(1));
+    let ip_id = ip_identity.register_work("", 'sealed_hash', 0);
+
+    cheat_caller_address(ip_identity.contract_address, collaborator(), CheatSpan::TargetCalls(1));
+    ip_identity.reveal(ip_id, "ipfs://not-yours");
+}
+
+#[test]
+#[should_panic(expected: ('IPID: invalid metadata',))]
+fn test_reveal_requires_nonempty_uri() {
+    let ip_identity = deploy_ip_identity();
+
+    cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(2));
+    let ip_id = ip_identity.register_work("", 'sealed_hash', 0);
+    ip_identity.reveal(ip_id, "");
+}

--- a/contracts/IP-ID/tests/test_contract.cairo
+++ b/contracts/IP-ID/tests/test_contract.cairo
@@ -290,3 +290,90 @@ fn test_controller_transfer_rejects_zero_address() {
     cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(1));
     ip_identity.transfer_controller(ip_id, zero_address());
 }
+
+#[test]
+fn test_relations_support_multiple_parents() {
+    let ip_identity = deploy_ip_identity();
+
+    cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(2));
+    let parent_a = ip_identity.register_work("ipfs://parent-a", 'parent_a_hash', 0);
+    let parent_b = ip_identity.register_work("ipfs://parent-b", 'parent_b_hash', 0);
+
+    cheat_caller_address(ip_identity.contract_address, collaborator(), CheatSpan::TargetCalls(3));
+    let remix = ip_identity.register_work("ipfs://remix", 'remix_hash', 0);
+    start_cheat_block_timestamp(ip_identity.contract_address, 4000);
+    let key_a = ip_identity.relate(remix, parent_a, 'DERIVATIVE');
+    stop_cheat_block_timestamp(ip_identity.contract_address);
+    let key_b = ip_identity.relate(remix, parent_b, 'DERIVATIVE');
+
+    let work = ip_identity.get_work(remix);
+    let relation = ip_identity.get_relation(key_a);
+    assert(work.relation_count == 2, 'wrong relation count');
+    assert(key_a == ip_identity.derive_relation_key(remix, parent_a, 'DERIVATIVE'), 'wrong key');
+    assert(ip_identity.get_work_relation_key(remix, 0) == key_a, 'wrong first key');
+    assert(ip_identity.get_work_relation_key(remix, 1) == key_b, 'wrong second key');
+    assert(ip_identity.get_relation_ip_id(key_a) == remix, 'wrong reverse link');
+    assert(relation.related_ip_id == parent_a, 'wrong related work');
+    assert(relation.relation_type == 'DERIVATIVE', 'wrong relation type');
+    assert(relation.asserted_by == collaborator(), 'wrong asserter');
+    assert(relation.asserted_at == 4000, 'wrong asserted timestamp');
+    assert(ip_identity.is_relation_asserted(key_a), 'relation not asserted');
+}
+
+#[test]
+#[should_panic(expected: ('IPID: not controller',))]
+fn test_only_controller_asserts_relations() {
+    let ip_identity = deploy_ip_identity();
+    let ip_id = register_default_work(ip_identity);
+
+    cheat_caller_address(ip_identity.contract_address, collaborator(), CheatSpan::TargetCalls(2));
+    let other = ip_identity.register_work("ipfs://other", 'other_hash', 0);
+    ip_identity.relate(ip_id, other, 'VERSION');
+}
+
+#[test]
+#[should_panic(expected: ('IPID: invalid work',))]
+fn test_relation_requires_existing_related_work() {
+    let ip_identity = deploy_ip_identity();
+    let ip_id = register_default_work(ip_identity);
+
+    cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(1));
+    ip_identity.relate(ip_id, 'missing_work_id', 'VERSION');
+}
+
+#[test]
+#[should_panic(expected: ('IPID: self relation',))]
+fn test_relation_rejects_self_reference() {
+    let ip_identity = deploy_ip_identity();
+    let ip_id = register_default_work(ip_identity);
+
+    cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(1));
+    ip_identity.relate(ip_id, ip_id, 'VERSION');
+}
+
+#[test]
+#[should_panic(expected: ('IPID: relation asserted',))]
+fn test_duplicate_relation_reverts() {
+    let ip_identity = deploy_ip_identity();
+    let ip_id = register_default_work(ip_identity);
+
+    cheat_caller_address(ip_identity.contract_address, collaborator(), CheatSpan::TargetCalls(1));
+    let other = ip_identity.register_work("ipfs://other", 'other_hash', 0);
+
+    cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(2));
+    ip_identity.relate(ip_id, other, 'VERSION');
+    ip_identity.relate(ip_id, other, 'VERSION');
+}
+
+#[test]
+#[should_panic(expected: ('IPID: invalid relation',))]
+fn test_relation_requires_type() {
+    let ip_identity = deploy_ip_identity();
+    let ip_id = register_default_work(ip_identity);
+
+    cheat_caller_address(ip_identity.contract_address, collaborator(), CheatSpan::TargetCalls(1));
+    let other = ip_identity.register_work("ipfs://other", 'other_hash', 0);
+
+    cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(1));
+    ip_identity.relate(ip_id, other, 0);
+}

--- a/contracts/IP-ID/tests/test_contract.cairo
+++ b/contracts/IP-ID/tests/test_contract.cairo
@@ -377,3 +377,109 @@ fn test_relation_requires_type() {
     cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(1));
     ip_identity.relate(ip_id, other, 0);
 }
+
+#[test]
+fn test_anyone_can_add_append_only_attestation() {
+    let ip_identity = deploy_ip_identity();
+    let ip_id = register_default_work(ip_identity);
+
+    cheat_caller_address(ip_identity.contract_address, collaborator(), CheatSpan::TargetCalls(1));
+    start_cheat_block_timestamp(ip_identity.contract_address, 3000);
+    let attestation_id = ip_identity
+        .attest(ip_id, 0, 'PROVENANCE', 'provenance_hash', "ipfs://provenance-proof");
+    stop_cheat_block_timestamp(ip_identity.contract_address);
+
+    let work = ip_identity.get_work(ip_id);
+    let attestation = ip_identity.get_attestation(ip_id, attestation_id);
+    assert(attestation_id == 1, 'wrong attestation id');
+    assert(work.attestation_count == 1, 'wrong attestation count');
+    assert(attestation.attester == collaborator(), 'wrong attester');
+    assert(attestation.subject_key == 0, 'wrong subject');
+    assert(attestation.attestation_type == 'PROVENANCE', 'wrong type');
+    assert(attestation.data_hash == 'provenance_hash', 'wrong data hash');
+    assert(attestation.uri == "ipfs://provenance-proof", 'wrong uri');
+    assert(attestation.created_at == 3000, 'wrong attestation timestamp');
+}
+
+#[test]
+#[should_panic(expected: ('IPID: invalid attestation',))]
+fn test_attestation_requires_type_and_hash() {
+    let ip_identity = deploy_ip_identity();
+    let ip_id = register_default_work(ip_identity);
+
+    cheat_caller_address(ip_identity.contract_address, collaborator(), CheatSpan::TargetCalls(1));
+    ip_identity.attest(ip_id, 0, 0, 'provenance_hash', "ipfs://provenance-proof");
+}
+
+#[test]
+fn test_dispute_targets_a_representation_claim() {
+    let ip_identity = deploy_ip_identity();
+    let ip_id = register_default_work(ip_identity);
+
+    cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(1));
+    ip_identity
+        .link_representation(
+            ip_id,
+            'bitcoin',
+            0,
+            0,
+            'inscription_hash',
+            "ipfs://ordinal-proof",
+            'ordinal_metadata_hash',
+            'ORDINAL',
+        );
+    let ordinal_key = ip_identity
+        .derive_representation_key('bitcoin', 0, 0, 'inscription_hash', 'ORDINAL');
+
+    cheat_caller_address(ip_identity.contract_address, collaborator(), CheatSpan::TargetCalls(1));
+    let attestation_id = ip_identity
+        .attest(ip_id, ordinal_key, 'DISPUTE', 'holder_sig_hash', "ipfs://dispute-proof");
+
+    let attestation = ip_identity.get_attestation(ip_id, attestation_id);
+    assert(attestation.subject_key == ordinal_key, 'wrong subject key');
+    assert(attestation.attestation_type == 'DISPUTE', 'wrong type');
+}
+
+#[test]
+fn test_confirm_targets_a_relation_claim() {
+    let ip_identity = deploy_ip_identity();
+    let ip_id = register_default_work(ip_identity);
+
+    cheat_caller_address(ip_identity.contract_address, collaborator(), CheatSpan::TargetCalls(1));
+    let parent = ip_identity.register_work("ipfs://parent", 'parent_hash', 0);
+
+    cheat_caller_address(ip_identity.contract_address, creator(), CheatSpan::TargetCalls(1));
+    let relation_key = ip_identity.relate(ip_id, parent, 'DERIVATIVE');
+
+    cheat_caller_address(ip_identity.contract_address, collaborator(), CheatSpan::TargetCalls(1));
+    let attestation_id = ip_identity
+        .attest(ip_id, relation_key, 'CONFIRM', 'consent_hash', "ipfs://confirm-proof");
+
+    let attestation = ip_identity.get_attestation(ip_id, attestation_id);
+    assert(attestation.subject_key == relation_key, 'wrong subject key');
+}
+
+#[test]
+#[should_panic(expected: ('IPID: invalid subject',))]
+fn test_attestation_rejects_unknown_subject() {
+    let ip_identity = deploy_ip_identity();
+    let ip_id = register_default_work(ip_identity);
+
+    cheat_caller_address(ip_identity.contract_address, collaborator(), CheatSpan::TargetCalls(1));
+    ip_identity.attest(ip_id, 'bogus_subject', 'CONFIRM', 'hash', "ipfs://proof");
+}
+
+#[test]
+#[should_panic(expected: ('IPID: invalid subject',))]
+fn test_attestation_rejects_other_works_subject() {
+    let ip_identity = deploy_ip_identity();
+    let ip_id = register_default_work(ip_identity);
+
+    cheat_caller_address(ip_identity.contract_address, collaborator(), CheatSpan::TargetCalls(2));
+    let other = ip_identity.register_work("ipfs://other", 'other_hash', 0);
+    ip_identity.link_representation(other, 'starknet', 0x999, 5, 0, "ipfs://t", 'h', 'ERC721');
+    let foreign_key = ip_identity.derive_representation_key('starknet', 0x999, 5, 0, 'ERC721');
+
+    cheat_caller_address(ip_identity.contract_address, collaborator(), CheatSpan::TargetCalls(1));
+    ip_identity.attest(ip_id, foreign_key, 'CONFIRM', 'hash', "ipfs://proof");
+}


### PR DESCRIPTION
## Summary

Redesign of the IP-ID work-identity contract. One coherent move: **portable content-derived IDs + everything-else-is-an-append-only-claim.**

- **Content-derived identity** — `ip_id = poseidon("IPID_WORK_V1", creator, metadata_hash, salt)` replaces the sequential counter. Identity survives contract redeploy and chain re-anchoring: the registry state is a pure function of its event log (replay = re-anchor). Duplicate registration reverts; two claimants of one content hash hold parallel claims with distinct IDs — the contract records claims, it never adjudicates.
- **Relations** — `parent_ip_id`/`parent_relation` replaced by append-only `relate(ip_id, related_ip_id, relation_type)` with contract-derived `IPID_RELATION_V1` keys. Multi-parent lineage by construction; controller-asserted; self-relations and duplicates rejected.
- **Targeted attestations** — `attest` gains `subject_key`: 0 targets the work, otherwise a representation or relation key of the same work. New canonical types `CONFIRM`/`DISPUTE` make claims symmetric (e.g. the other-chain holder of a linked asset can consent to or dispute the link, which is claim-grade, not authoritative).
- **Commit-then-reveal** — registering with an empty `metadata_uri` is a first-class sealed registration (commitment + proof-of-existence timestamp); `reveal` is controller-only and one-time.
- **Reserved seams** — `ATTESTATION_ANCHOR` constant (Bitcoin PoE anchoring, no logic); signed registration and the canonical locator-hashing codec documented in the README as SDK-side seams.

Unchanged by design: representation keying, controller model, zero fees, no admin/owner/upgrade, no mutable licensing, no ERC-721 identity carrier.

Version 0.2.0 → 0.3.0.

## Testing

29 snforge tests, all passing (`scarb test`), including: ID determinism across two separate deployments (the portability proof), duplicate/parallel-claim behavior, multi-parent relations, targeted confirm/dispute attestations (foreign subjects rejected), and the sealed→reveal lifecycle. `scarb fmt` + clean `scarb build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)