### PR TITLE
CI: detect step no longer fails on non-Cairo contract dirs

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -27,9 +27,12 @@ jobs:
             BASE="${{ github.event.before }}"
             git cat-file -e "$BASE" 2>/dev/null || BASE="HEAD~1"
           fi
+          # Non-Cairo packages (EVM/Solana/Soroban) have no Scarb.toml and are
+          # skipped without failing the pipeline (set -e + pipefail would
+          # otherwise kill the job when the last changed dir is non-Cairo).
           DIRS=$(git diff --name-only "$BASE"...HEAD -- 'contracts/**' \
             | cut -d/ -f1-2 | sort -u \
-            | while read -r d; do [ -f "$d/Scarb.toml" ] && echo "$d"; done \
+            | while read -r d; do if [ -f "$d/Scarb.toml" ]; then echo "$d"; fi; done \
             | jq -R -s -c 'split("\n") | map(select(length > 0))')
           echo "dirs=${DIRS:-[]}" >> "$GITHUB_OUTPUT"
           echo "Changed contract dirs: ${DIRS:-[]}"


### PR DESCRIPTION
The `detect` job filters changed `contracts/*` dirs to those with a `Scarb.toml`. Under `set -e -o pipefail`, the filter loop's exit status is the last `[ -f ]` test — so any change set whose last dir is non-Cairo (EVM/Solana/Soroban packages) killed the job before producing output. Every run since #151 failed this way without building anything.

The test now runs in an `if` so a non-Cairo dir is skipped, not fatal. Non-Cairo change sets produce an empty matrix and the build job is skipped, as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)