### PR TITLE
IP Sponsorship v3: soft-enforced license + symmetric proposals

### DIFF
--- a/contracts/IP-Sponsorhip/src/IPSponsorship.cairo
+++ b/contracts/IP-Sponsorhip/src/IPSponsorship.cairo
@@ -7,6 +7,9 @@
 // proposals are allowance-based — no escrow, the contract never holds
 // funds; on acceptance, payment settles sponsor → author directly and a
 // license mints as a standard ERC-721 on IPSponsorshipLicense, atomically.
+// Retracting a bid or withdrawing a proposal is advisory against an
+// acceptance in flight in the same block; revoking the ERC-20 allowance is
+// the guaranteed cancel, as acceptance settles against that allowance.
 // An issued license cannot be revoked by anyone — it runs to its expiry.
 // No contract owner, no admin, no fee.
 #[starknet::contract]
@@ -23,9 +26,7 @@ pub mod IPSponsorship {
         IIPSponsorship, IIPSponsorshipLicenseDispatcher, IIPSponsorshipLicenseDispatcherTrait,
         IIP_SPONSORSHIP_ID,
     };
-    use crate::types::{
-        LicenseData, SponsorshipOffer, SponsorshipProposal, bytearray_starts_with,
-    };
+    use crate::types::{LicenseData, SponsorshipOffer, SponsorshipProposal, bytearray_starts_with};
 
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
 
@@ -135,6 +136,7 @@ pub mod IPSponsorship {
         pub token_id: u256,
         pub amount: u256,
         pub duration: u64,
+        pub valid_until: u64,
         pub payment_token: ContractAddress,
         pub license_terms_uri: ByteArray,
         pub transferable: bool,
@@ -310,8 +312,7 @@ pub mod IPSponsorship {
             self.offers.entry(offer_id).write(offer.clone());
             self.bids.entry((offer_id, sponsor)).write(0);
 
-            let expires_at = get_block_timestamp() + offer.duration;
-            let license_id = self
+            let (license_id, expires_at) = self
                 .settle_and_mint(
                     caller,
                     sponsor,
@@ -341,6 +342,7 @@ pub mod IPSponsorship {
             token_id: u256,
             amount: u256,
             duration: u64,
+            valid_until: u64,
             payment_token: ContractAddress,
             license_terms_uri: ByteArray,
             transferable: bool,
@@ -350,6 +352,7 @@ pub mod IPSponsorship {
             assert(!proposer.is_zero(), 'Proposer is zero address');
             assert(duration > 0, 'Duration cannot be zero');
             assert(amount > 0, 'Amount cannot be zero');
+            assert(valid_until == 0 || valid_until > get_block_timestamp(), 'Deadline in the past');
             assert(!payment_token.is_zero(), 'Payment token is zero');
             assert(!nft_contract.is_zero(), 'NFT contract is zero');
             assert(royalty_bps <= 10000, 'Royalty exceeds 10000');
@@ -368,6 +371,7 @@ pub mod IPSponsorship {
                         token_id,
                         amount,
                         duration,
+                        valid_until,
                         payment_token,
                         license_terms_uri: license_terms_uri.clone(),
                         transferable,
@@ -386,6 +390,7 @@ pub mod IPSponsorship {
                         token_id,
                         amount,
                         duration,
+                        valid_until,
                         payment_token,
                         license_terms_uri,
                         transferable,
@@ -418,11 +423,13 @@ pub mod IPSponsorship {
             assert(!proposal.proposer.is_zero(), 'Proposal does not exist');
             assert(proposal.open, 'Proposal not open');
 
+            // Effects before interactions: close before the external
+            // ownership read; a failing assert reverts the write.
+            proposal.open = false;
+            self.proposals.entry(proposal_id).write(proposal.clone());
+
             let nft = IERC721Dispatcher { contract_address: proposal.nft_contract };
             assert(nft.owner_of(proposal.token_id) == get_caller_address(), 'Not IP owner');
-
-            proposal.open = false;
-            self.proposals.entry(proposal_id).write(proposal);
 
             self
                 .emit(
@@ -437,12 +444,13 @@ pub mod IPSponsorship {
             let mut proposal = self.proposals.entry(proposal_id).read();
             assert(!proposal.proposer.is_zero(), 'Proposal does not exist');
             assert(proposal.open, 'Proposal not open');
+            let now = get_block_timestamp();
+            assert(proposal.valid_until == 0 || now <= proposal.valid_until, 'Proposal expired');
 
             proposal.open = false;
             self.proposals.entry(proposal_id).write(proposal.clone());
 
-            let expires_at = get_block_timestamp() + proposal.duration;
-            let license_id = self
+            let (license_id, expires_at) = self
                 .settle_and_mint(
                     caller,
                     proposal.proposer,
@@ -456,6 +464,7 @@ pub mod IPSponsorship {
                     proposal.license_terms_uri.clone(),
                 );
 
+            self.emit(ProposalClosed { proposal_id, accepted: true, closed_at: now });
             self
                 .emit(
                     ProposalAccepted {
@@ -532,6 +541,7 @@ pub mod IPSponsorship {
         // payment settles sponsor → author directly against the allowance
         // the sponsor holds open, and the license mints to the sponsor —
         // all atomically, so a failing transfer reverts the mint too.
+        // Returns (license_id, expires_at).
         fn settle_and_mint(
             ref self: ContractState,
             author: ContractAddress,
@@ -544,7 +554,7 @@ pub mod IPSponsorship {
             transferable: bool,
             royalty_bps: u256,
             license_terms_uri: ByteArray,
-        ) -> u256 {
+        ) -> (u256, u64) {
             let nft = IERC721Dispatcher { contract_address: nft_contract };
             assert(nft.owner_of(token_id) == author, 'Not IP owner');
 
@@ -567,7 +577,7 @@ pub mod IPSponsorship {
             let result = token.transfer_from(sponsor, author, amount);
             assert(result, 'Token Transfer Failed');
 
-            license_id
+            (license_id, expires_at)
         }
     }
 }

--- a/contracts/IP-Sponsorhip/src/IPSponsorship.cairo
+++ b/contracts/IP-Sponsorhip/src/IPSponsorship.cairo
@@ -1,12 +1,14 @@
-// IP-Sponsorship v2 — permissionless sponsorship offers on ERC-721 IP assets.
+// IP-Sponsorship — permissionless sponsorship on ERC-721 IP assets.
 //
-// An IP owner offers a time-bound sponsorship license on an asset they hold
-// (any ERC-721 — the asset layer is the registry; this contract keeps none).
-// Sponsors signal bids (allowance-based — no escrow, the contract never holds
-// funds); the author accepts one, payment settles sponsor → author directly,
-// and a license is minted as a standard ERC-721 on IPSponsorshipLicense. An
-// issued license cannot be revoked by anyone — it runs to its expiry. No
-// contract owner, no admin, no fee.
+// Either side can initiate: an IP owner offers a time-bound sponsorship
+// license on an asset they hold and sponsors bid on it, or a sponsor
+// proposes terms directly and the owner accepts or rejects (any ERC-721 —
+// the asset layer is the registry; this contract keeps none). Bids and
+// proposals are allowance-based — no escrow, the contract never holds
+// funds; on acceptance, payment settles sponsor → author directly and a
+// license mints as a standard ERC-721 on IPSponsorshipLicense, atomically.
+// An issued license cannot be revoked by anyone — it runs to its expiry.
+// No contract owner, no admin, no fee.
 #[starknet::contract]
 pub mod IPSponsorship {
     use core::num::traits::Zero;
@@ -21,7 +23,9 @@ pub mod IPSponsorship {
         IIPSponsorship, IIPSponsorshipLicenseDispatcher, IIPSponsorshipLicenseDispatcherTrait,
         IIP_SPONSORSHIP_ID,
     };
-    use crate::types::{LicenseData, SponsorshipOffer, bytearray_starts_with};
+    use crate::types::{
+        LicenseData, SponsorshipOffer, SponsorshipProposal, bytearray_starts_with,
+    };
 
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
 
@@ -42,6 +46,8 @@ pub mod IPSponsorship {
         // One standing bid per sponsor per offer; rebidding overwrites.
         // History lives in events; no enumerable bid lists on-chain.
         bids: Map<(u256, ContractAddress), u256>,
+        last_proposal_id: u256,
+        proposals: Map<u256, SponsorshipProposal>,
     }
 
     #[event]
@@ -54,6 +60,9 @@ pub mod IPSponsorship {
         BidPlaced: BidPlaced,
         BidRetracted: BidRetracted,
         SponsorshipAccepted: SponsorshipAccepted,
+        ProposalCreated: ProposalCreated,
+        ProposalClosed: ProposalClosed,
+        ProposalAccepted: ProposalAccepted,
     }
 
     #[derive(Drop, starknet::Event)]
@@ -106,6 +115,45 @@ pub mod IPSponsorship {
     pub struct SponsorshipAccepted {
         #[key]
         pub offer_id: u256,
+        #[key]
+        pub license_id: u256,
+        #[key]
+        pub sponsor: ContractAddress,
+        pub author: ContractAddress,
+        pub amount: u256,
+        pub expires_at: u64,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    pub struct ProposalCreated {
+        #[key]
+        pub proposal_id: u256,
+        #[key]
+        pub proposer: ContractAddress,
+        #[key]
+        pub nft_contract: ContractAddress,
+        pub token_id: u256,
+        pub amount: u256,
+        pub duration: u64,
+        pub payment_token: ContractAddress,
+        pub license_terms_uri: ByteArray,
+        pub transferable: bool,
+        pub royalty_bps: u256,
+        pub created_at: u64,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    pub struct ProposalClosed {
+        #[key]
+        pub proposal_id: u256,
+        pub accepted: bool,
+        pub closed_at: u64,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    pub struct ProposalAccepted {
+        #[key]
+        pub proposal_id: u256,
         #[key]
         pub license_id: u256,
         #[key]
@@ -256,42 +304,26 @@ pub mod IPSponsorship {
             let amount = self.bids.entry((offer_id, sponsor)).read();
             assert(amount > 0, 'No standing bid');
 
-            // The author must still own the IP they are licensing — an offer
-            // does not survive the sale of the underlying asset.
-            let nft = IERC721Dispatcher { contract_address: offer.nft_contract };
-            assert(nft.owner_of(offer.token_id) == caller, 'Not IP owner');
-
-            let now = get_block_timestamp();
-            let expires_at = now + offer.duration;
-
             // Effects before interactions: the offer closes and the accepted
             // bid is consumed before any external call.
             offer.open = false;
-            let payment_token = offer.payment_token;
-            let license_data = LicenseData {
-                author: caller,
-                asset_contract: offer.nft_contract,
-                asset_token_id: offer.token_id,
-                expires_at,
-                transferable: offer.transferable,
-                royalty_bps: offer.royalty_bps,
-                license_terms_uri: offer.license_terms_uri.clone(),
-            };
-            self.offers.entry(offer_id).write(offer);
+            self.offers.entry(offer_id).write(offer.clone());
             self.bids.entry((offer_id, sponsor)).write(0);
 
-            // The license is a standard ERC-721 minted to the sponsor.
-            let license_nft = IIPSponsorshipLicenseDispatcher {
-                contract_address: self.license_contract.read(),
-            };
-            let license_id = license_nft.mint(sponsor, license_data);
-
-            // Settlement: sponsor → author directly, against the allowance
-            // the sponsor holds open. No escrow — a failing transfer reverts
-            // the whole acceptance atomically, including the mint.
-            let token = IERC20Dispatcher { contract_address: payment_token };
-            let result = token.transfer_from(sponsor, caller, amount);
-            assert(result, 'Token Transfer Failed');
+            let expires_at = get_block_timestamp() + offer.duration;
+            let license_id = self
+                .settle_and_mint(
+                    caller,
+                    sponsor,
+                    offer.nft_contract,
+                    offer.token_id,
+                    offer.payment_token,
+                    amount,
+                    offer.duration,
+                    offer.transferable,
+                    offer.royalty_bps,
+                    offer.license_terms_uri.clone(),
+                );
 
             self
                 .emit(
@@ -301,6 +333,152 @@ pub mod IPSponsorship {
                 );
 
             license_id
+        }
+
+        fn propose_sponsorship(
+            ref self: ContractState,
+            nft_contract: ContractAddress,
+            token_id: u256,
+            amount: u256,
+            duration: u64,
+            payment_token: ContractAddress,
+            license_terms_uri: ByteArray,
+            transferable: bool,
+            royalty_bps: u256,
+        ) -> u256 {
+            let proposer = get_caller_address();
+            assert(!proposer.is_zero(), 'Proposer is zero address');
+            assert(duration > 0, 'Duration cannot be zero');
+            assert(amount > 0, 'Amount cannot be zero');
+            assert(!payment_token.is_zero(), 'Payment token is zero');
+            assert(!nft_contract.is_zero(), 'NFT contract is zero');
+            assert(royalty_bps <= 10000, 'Royalty exceeds 10000');
+            let valid_uri = bytearray_starts_with(@license_terms_uri, @"ipfs://")
+                || bytearray_starts_with(@license_terms_uri, @"ar://");
+            assert(valid_uri, 'URI must be ipfs:// or ar://');
+
+            let proposal_id = self.last_proposal_id.read() + 1;
+            self
+                .proposals
+                .entry(proposal_id)
+                .write(
+                    SponsorshipProposal {
+                        proposer,
+                        nft_contract,
+                        token_id,
+                        amount,
+                        duration,
+                        payment_token,
+                        license_terms_uri: license_terms_uri.clone(),
+                        transferable,
+                        open: true,
+                        royalty_bps,
+                    },
+                );
+            self.last_proposal_id.write(proposal_id);
+
+            self
+                .emit(
+                    ProposalCreated {
+                        proposal_id,
+                        proposer,
+                        nft_contract,
+                        token_id,
+                        amount,
+                        duration,
+                        payment_token,
+                        license_terms_uri,
+                        transferable,
+                        royalty_bps,
+                        created_at: get_block_timestamp(),
+                    },
+                );
+            proposal_id
+        }
+
+        fn withdraw_proposal(ref self: ContractState, proposal_id: u256) {
+            let mut proposal = self.proposals.entry(proposal_id).read();
+            assert(!proposal.proposer.is_zero(), 'Proposal does not exist');
+            assert(proposal.proposer == get_caller_address(), 'Only proposer');
+            assert(proposal.open, 'Proposal not open');
+
+            proposal.open = false;
+            self.proposals.entry(proposal_id).write(proposal);
+
+            self
+                .emit(
+                    ProposalClosed {
+                        proposal_id, accepted: false, closed_at: get_block_timestamp(),
+                    },
+                );
+        }
+
+        fn reject_proposal(ref self: ContractState, proposal_id: u256) {
+            let mut proposal = self.proposals.entry(proposal_id).read();
+            assert(!proposal.proposer.is_zero(), 'Proposal does not exist');
+            assert(proposal.open, 'Proposal not open');
+
+            let nft = IERC721Dispatcher { contract_address: proposal.nft_contract };
+            assert(nft.owner_of(proposal.token_id) == get_caller_address(), 'Not IP owner');
+
+            proposal.open = false;
+            self.proposals.entry(proposal_id).write(proposal);
+
+            self
+                .emit(
+                    ProposalClosed {
+                        proposal_id, accepted: false, closed_at: get_block_timestamp(),
+                    },
+                );
+        }
+
+        fn accept_proposal(ref self: ContractState, proposal_id: u256) -> u256 {
+            let caller = get_caller_address();
+            let mut proposal = self.proposals.entry(proposal_id).read();
+            assert(!proposal.proposer.is_zero(), 'Proposal does not exist');
+            assert(proposal.open, 'Proposal not open');
+
+            proposal.open = false;
+            self.proposals.entry(proposal_id).write(proposal.clone());
+
+            let expires_at = get_block_timestamp() + proposal.duration;
+            let license_id = self
+                .settle_and_mint(
+                    caller,
+                    proposal.proposer,
+                    proposal.nft_contract,
+                    proposal.token_id,
+                    proposal.payment_token,
+                    proposal.amount,
+                    proposal.duration,
+                    proposal.transferable,
+                    proposal.royalty_bps,
+                    proposal.license_terms_uri.clone(),
+                );
+
+            self
+                .emit(
+                    ProposalAccepted {
+                        proposal_id,
+                        license_id,
+                        sponsor: proposal.proposer,
+                        author: caller,
+                        amount: proposal.amount,
+                        expires_at,
+                    },
+                );
+
+            license_id
+        }
+
+        fn get_proposal(self: @ContractState, proposal_id: u256) -> SponsorshipProposal {
+            let proposal = self.proposals.entry(proposal_id).read();
+            assert(!proposal.proposer.is_zero(), 'Proposal does not exist');
+            proposal
+        }
+
+        fn get_last_proposal_id(self: @ContractState) -> u256 {
+            self.last_proposal_id.read()
         }
 
         fn get_offer(self: @ContractState, offer_id: u256) -> SponsorshipOffer {
@@ -343,7 +521,53 @@ pub mod IPSponsorship {
         }
 
         fn version(self: @ContractState) -> ByteArray {
-            "2.0.0"
+            "3.0.0"
+        }
+    }
+
+    #[generate_trait]
+    impl InternalImpl of InternalTrait {
+        // The author must still own the IP they are licensing (an offer or
+        // proposal does not survive the sale of the underlying asset),
+        // payment settles sponsor → author directly against the allowance
+        // the sponsor holds open, and the license mints to the sponsor —
+        // all atomically, so a failing transfer reverts the mint too.
+        fn settle_and_mint(
+            ref self: ContractState,
+            author: ContractAddress,
+            sponsor: ContractAddress,
+            nft_contract: ContractAddress,
+            token_id: u256,
+            payment_token: ContractAddress,
+            amount: u256,
+            duration: u64,
+            transferable: bool,
+            royalty_bps: u256,
+            license_terms_uri: ByteArray,
+        ) -> u256 {
+            let nft = IERC721Dispatcher { contract_address: nft_contract };
+            assert(nft.owner_of(token_id) == author, 'Not IP owner');
+
+            let expires_at = get_block_timestamp() + duration;
+            let license_data = LicenseData {
+                author,
+                asset_contract: nft_contract,
+                asset_token_id: token_id,
+                expires_at,
+                transferable,
+                royalty_bps,
+                license_terms_uri,
+            };
+            let license_nft = IIPSponsorshipLicenseDispatcher {
+                contract_address: self.license_contract.read(),
+            };
+            let license_id = license_nft.mint(sponsor, license_data);
+
+            let token = IERC20Dispatcher { contract_address: payment_token };
+            let result = token.transfer_from(sponsor, author, amount);
+            assert(result, 'Token Transfer Failed');
+
+            license_id
         }
     }
 }

--- a/contracts/IP-Sponsorhip/src/IPSponsorshipLicense.cairo
+++ b/contracts/IP-Sponsorhip/src/IPSponsorshipLicense.cairo
@@ -12,8 +12,8 @@ pub mod IPSponsorshipLicense {
     use core::num::traits::Zero;
     use openzeppelin_introspection::src5::SRC5Component;
     use openzeppelin_token::common::erc2981::interface::IERC2981_ID;
-    use openzeppelin_token::erc721::ERC721Component;
     use openzeppelin_token::erc721::interface::{IERC721Metadata, IERC721MetadataCamelOnly};
+    use openzeppelin_token::erc721::{ERC721Component, ERC721HooksEmptyImpl};
     use starknet::storage::{
         Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
         StoragePointerWriteAccess,
@@ -86,22 +86,6 @@ pub mod IPSponsorshipLicense {
         self.src5.register_interface(IIP_SPONSORSHIP_LICENSE_ID);
         self.src5.register_interface(IERC2981_ID);
         self.src5.register_interface(ILICENSED_COLLECTION_ID);
-    }
-
-    impl ERC721HooksImpl of ERC721Component::ERC721HooksTrait<ContractState> {
-        fn before_update(
-            ref self: ERC721Component::ComponentState<ContractState>,
-            to: ContractAddress,
-            token_id: u256,
-            auth: ContractAddress,
-        ) {}
-
-        fn after_update(
-            ref self: ERC721Component::ComponentState<ContractState>,
-            to: ContractAddress,
-            token_id: u256,
-            auth: ContractAddress,
-        ) {}
     }
 
     #[abi(embed_v0)]

--- a/contracts/IP-Sponsorhip/src/IPSponsorshipLicense.cairo
+++ b/contracts/IP-Sponsorhip/src/IPSponsorshipLicense.cairo
@@ -1,11 +1,12 @@
-// The sponsorship license token: a standard ERC-721 whose holder is the
-// current licensee. Minted only by the IPSponsorship registry when an offer
-// is accepted. Transferability and expiry are properties of each license,
-// enforced in the transfer hook; a transferable, unexpired license moves
-// through ordinary transfer_from/safe_transfer_from and is therefore
-// listable and holdable by any ERC-721-aware wallet, marketplace, or agent.
-// EIP-2981 royalties on resale pay the IP author. Ownerless after the
-// one-time minter bootstrap.
+// The sponsorship license token: a standard, freely transferable ERC-721
+// whose holder is the current licensee. Minted only by the IPSponsorship
+// registry when an offer or proposal is accepted. Listable and holdable by
+// any ERC-721-aware wallet, marketplace, or agent. EIP-2981 royalties on
+// resale pay the IP author. Ownerless after the one-time minter bootstrap.
+// License terms — including whether the issuing author intended the
+// license to be resold, and its expiry — are declarative, carried in
+// license_terms_uri metadata and readable via is_license_valid(); this
+// contract does not enforce them against a transfer.
 #[starknet::contract]
 pub mod IPSponsorshipLicense {
     use core::num::traits::Zero;
@@ -93,18 +94,7 @@ pub mod IPSponsorshipLicense {
             to: ContractAddress,
             token_id: u256,
             auth: ContractAddress,
-        ) {
-            let contract_state = self.get_contract();
-            let current_owner = contract_state.erc721.ERC721_owners.read(token_id);
-            // Mint and burn are always permitted; holder-to-holder movement
-            // requires a transferable, unexpired license.
-            if current_owner.is_zero() || to.is_zero() {
-                return;
-            }
-            let data = contract_state.licenses.read(token_id);
-            assert(data.transferable, 'License not transferable');
-            assert(get_block_timestamp() < data.expires_at, 'License expired');
-        }
+        ) {}
 
         fn after_update(
             ref self: ERC721Component::ComponentState<ContractState>,
@@ -218,7 +208,7 @@ pub mod IPSponsorshipLicense {
         }
 
         fn version(self: @ContractState) -> ByteArray {
-            "2.0.0"
+            "3.0.0"
         }
     }
 }

--- a/contracts/IP-Sponsorhip/src/interface.cairo
+++ b/contracts/IP-Sponsorhip/src/interface.cairo
@@ -1,15 +1,15 @@
 use starknet::ContractAddress;
-use crate::types::{LicenseData, SponsorshipOffer};
+use crate::types::{LicenseData, SponsorshipOffer, SponsorshipProposal};
 
 // Protocol discovery ID registered via SRC5.
-// Derivation: starknet_keccak("mediolano.ip-sponsorship.v2").
+// Derivation: starknet_keccak("mediolano.ip-sponsorship.v3").
 pub const IIP_SPONSORSHIP_ID: felt252 =
-    0x0034e46e7acd46043d30df2ef53d27bbb6b7636b61c4e27e989e3bee5575bba5;
+    0x2acdd68e9e446816f8a4f4667264ce04d0bc9b85a519f7db14c0cf08a606ef3;
 
-// The sponsorship license as a standard, optionally transferable ERC-721.
-// Derivation: starknet_keccak("mediolano.ip-sponsorship-license.v1").
+// The sponsorship license as a standard, freely transferable ERC-721.
+// Derivation: starknet_keccak("mediolano.ip-sponsorship-license.v2").
 pub const IIP_SPONSORSHIP_LICENSE_ID: felt252 =
-    0x1a3bb9f33f57c7927ea7188d4a7f91ec8e4b801879f3cfc5be7722ac04c9cc7;
+    0xb14de94286e27cd2927d0c2bad0718857f9ad194efacfa09eb639e4dc5c190;
 
 // Marks a collection whose metadata JSON carries the Mediolano programmable
 // license trait schema (License, Commercial Use, Derivatives, Attribution,
@@ -44,6 +44,25 @@ pub trait IIPSponsorship<TContractState> {
     fn get_last_offer_id(self: @TContractState) -> u256;
     fn get_last_license_id(self: @TContractState) -> u256;
     fn get_license_contract(self: @TContractState) -> ContractAddress;
+    // A sponsor proposes terms on an asset with no open offer yet — the
+    // symmetric counterpart to create_offer. Any caller may propose; only
+    // the asset's current owner may accept or reject.
+    fn propose_sponsorship(
+        ref self: TContractState,
+        nft_contract: ContractAddress,
+        token_id: u256,
+        amount: u256,
+        duration: u64,
+        payment_token: ContractAddress,
+        license_terms_uri: ByteArray,
+        transferable: bool,
+        royalty_bps: u256,
+    ) -> u256;
+    fn withdraw_proposal(ref self: TContractState, proposal_id: u256);
+    fn accept_proposal(ref self: TContractState, proposal_id: u256) -> u256;
+    fn reject_proposal(ref self: TContractState, proposal_id: u256);
+    fn get_proposal(self: @TContractState, proposal_id: u256) -> SponsorshipProposal;
+    fn get_last_proposal_id(self: @TContractState) -> u256;
     fn version(self: @TContractState) -> ByteArray;
 }
 

--- a/contracts/IP-Sponsorhip/src/interface.cairo
+++ b/contracts/IP-Sponsorhip/src/interface.cairo
@@ -46,18 +46,23 @@ pub trait IIPSponsorship<TContractState> {
     fn get_license_contract(self: @TContractState) -> ContractAddress;
     // A sponsor proposes terms on an asset with no open offer yet — the
     // symmetric counterpart to create_offer. Any caller may propose; only
-    // the asset's current owner may accept or reject.
+    // the asset's current owner may accept or reject. valid_until is an
+    // acceptance deadline (unix seconds; 0 = no deadline).
     fn propose_sponsorship(
         ref self: TContractState,
         nft_contract: ContractAddress,
         token_id: u256,
         amount: u256,
         duration: u64,
+        valid_until: u64,
         payment_token: ContractAddress,
         license_terms_uri: ByteArray,
         transferable: bool,
         royalty_bps: u256,
     ) -> u256;
+    // Withdrawal (like bid retraction) is advisory against an in-flight
+    // acceptance in the same block — revoking the ERC-20 allowance is the
+    // guaranteed cancel, as acceptance settles against that allowance.
     fn withdraw_proposal(ref self: TContractState, proposal_id: u256);
     fn accept_proposal(ref self: TContractState, proposal_id: u256) -> u256;
     fn reject_proposal(ref self: TContractState, proposal_id: u256);

--- a/contracts/IP-Sponsorhip/src/types.cairo
+++ b/contracts/IP-Sponsorhip/src/types.cairo
@@ -22,7 +22,9 @@ pub struct SponsorshipOffer {
 /// The on-chain facts of an issued sponsorship license. Stored per-token on
 /// IPSponsorshipLicense; the current holder is the token's ERC-721 owner.
 /// The human/machine-readable terms live in the content-addressed
-/// license_terms_uri metadata (the token's URI).
+/// license_terms_uri metadata (the token's URI). transferable and
+/// expires_at are declarative — read by is_license_valid() and by
+/// integrators, never enforced against a transfer.
 #[derive(Drop, Serde, starknet::Store, Clone)]
 pub struct LicenseData {
     /// The IP author who issued the license (royalty recipient on resale).
@@ -30,15 +32,32 @@ pub struct LicenseData {
     /// The licensed IP asset.
     pub asset_contract: ContractAddress,
     pub asset_token_id: u256,
-    /// License validity end (unix seconds). Expiry is contract-enforced:
-    /// an expired license cannot transfer and reads as invalid.
+    /// License validity end (unix seconds), read by is_license_valid().
     pub expires_at: u64,
-    /// Whether the holder may transfer the license (set from the offer).
+    /// The issuing author's declared intent (set from the offer/proposal).
     pub transferable: bool,
     /// EIP-2981 royalty to the author on license resale, basis points.
     pub royalty_bps: u256,
     /// Content-addressed license terms (ipfs:// or ar://) — the token URI.
     pub license_terms_uri: ByteArray,
+}
+
+// A sponsor-initiated proposal on an asset with no open offer yet — the
+// symmetric counterpart to SponsorshipOffer. Existence: `proposer != 0`.
+// `open` gates acceptance/rejection; a withdrawn or accepted proposal is
+// closed and cannot be reopened — a new one is proposed instead.
+#[derive(Drop, Serde, starknet::Store, Clone)]
+pub struct SponsorshipProposal {
+    pub proposer: ContractAddress,
+    pub nft_contract: ContractAddress,
+    pub token_id: u256,
+    pub amount: u256,
+    pub duration: u64,
+    pub payment_token: ContractAddress,
+    pub license_terms_uri: ByteArray,
+    pub transferable: bool,
+    pub open: bool,
+    pub royalty_bps: u256,
 }
 
 pub fn bytearray_starts_with(haystack: @ByteArray, needle: @ByteArray) -> bool {

--- a/contracts/IP-Sponsorhip/src/types.cairo
+++ b/contracts/IP-Sponsorhip/src/types.cairo
@@ -45,7 +45,9 @@ pub struct LicenseData {
 // A sponsor-initiated proposal on an asset with no open offer yet — the
 // symmetric counterpart to SponsorshipOffer. Existence: `proposer != 0`.
 // `open` gates acceptance/rejection; a withdrawn or accepted proposal is
-// closed and cannot be reopened — a new one is proposed instead.
+// closed and cannot be reopened — a new one is proposed instead. The
+// proposal binds to the asset, not a person: whoever owns the asset at
+// acceptance time is the author who is paid and issues the license.
 #[derive(Drop, Serde, starknet::Store, Clone)]
 pub struct SponsorshipProposal {
     pub proposer: ContractAddress,
@@ -53,6 +55,9 @@ pub struct SponsorshipProposal {
     pub token_id: u256,
     pub amount: u256,
     pub duration: u64,
+    /// Acceptance deadline (unix seconds; 0 = no deadline). An expired
+    /// proposal can no longer be accepted.
+    pub valid_until: u64,
     pub payment_token: ContractAddress,
     pub license_terms_uri: ByteArray,
     pub transferable: bool,

--- a/contracts/IP-Sponsorhip/tests/test_contract.cairo
+++ b/contracts/IP-Sponsorhip/tests/test_contract.cairo
@@ -481,8 +481,10 @@ fn test_transferable_license_moves_via_standard_transfer() {
 }
 
 #[test]
-#[should_panic(expected: 'License not transferable')]
-fn test_nontransferable_license_blocks_transfer() {
+fn test_nontransferable_expired_license_still_transfers() {
+    // A `transferable: false`, already-expired license carries those facts
+    // as declarative terms only — the contract never gates a transfer on
+    // them.
     let (sponsorship, license_nft) = deploy_sponsorship_pair();
     let token = deploy_erc20();
     let nft = deploy_ip_nft_for(AUTHOR());
@@ -496,25 +498,6 @@ fn test_nontransferable_license_blocks_transfer() {
     cheat_caller_address(sponsorship.contract_address, SPONSOR1(), CheatSpan::TargetCalls(1));
     sponsorship.place_bid(offer_id, 250);
     fund_and_approve(token, SPONSOR1(), sponsorship.contract_address, 250);
-    cheat_caller_address(sponsorship.contract_address, AUTHOR(), CheatSpan::TargetCalls(1));
-    let license_id = sponsorship.accept_bid(offer_id, SPONSOR1());
-
-    let erc721 = IERC721Dispatcher { contract_address: license_nft.contract_address };
-    cheat_caller_address(license_nft.contract_address, SPONSOR1(), CheatSpan::TargetCalls(1));
-    erc721.transfer_from(SPONSOR1(), SPONSOR2(), license_id);
-}
-
-#[test]
-#[should_panic(expected: 'License expired')]
-fn test_expired_license_cannot_transfer() {
-    let (sponsorship, license_nft) = deploy_sponsorship_pair();
-    let token = deploy_erc20();
-    let nft = deploy_ip_nft_for(AUTHOR());
-    let offer_id = create_offer(sponsorship, nft, token.contract_address);
-
-    cheat_caller_address(sponsorship.contract_address, SPONSOR1(), CheatSpan::TargetCalls(1));
-    sponsorship.place_bid(offer_id, 250);
-    fund_and_approve(token, SPONSOR1(), sponsorship.contract_address, 250);
     cheat_block_timestamp(sponsorship.contract_address, 1000, CheatSpan::TargetCalls(1));
     cheat_caller_address(sponsorship.contract_address, AUTHOR(), CheatSpan::TargetCalls(1));
     let license_id = sponsorship.accept_bid(offer_id, SPONSOR1());
@@ -523,6 +506,11 @@ fn test_expired_license_cannot_transfer() {
     let erc721 = IERC721Dispatcher { contract_address: license_nft.contract_address };
     cheat_caller_address(license_nft.contract_address, SPONSOR1(), CheatSpan::TargetCalls(1));
     erc721.transfer_from(SPONSOR1(), SPONSOR2(), license_id);
+
+    assert(erc721.owner_of(license_id) == SPONSOR2(), 'transfer should have succeeded');
+    // is_license_valid is an informational read, independent of transfer.
+    cheat_block_timestamp(license_nft.contract_address, 1001 + DAY, CheatSpan::TargetCalls(1));
+    assert(!sponsorship.is_license_valid(license_id), 'should read as expired');
 }
 
 #[test]
@@ -668,8 +656,8 @@ fn test_missing_license_reverts() {
 #[test]
 fn test_version_views() {
     let (sponsorship, license_nft) = deploy_sponsorship_pair();
-    assert(sponsorship.version() == "2.0.0", 'sponsorship version');
-    assert(license_nft.version() == "2.0.0", 'license version');
+    assert(sponsorship.version() == "3.0.0", 'sponsorship version');
+    assert(license_nft.version() == "3.0.0", 'license version');
 }
 
 #[test]
@@ -715,4 +703,116 @@ fn test_license_minted_event_carries_royalty_and_terms() {
                 ),
             ],
         );
+}
+
+// --- sponsor-initiated proposals ---
+
+#[test]
+fn test_propose_sponsorship_then_owner_accepts() {
+    let (sponsorship, license_nft) = deploy_sponsorship_pair();
+    let token = deploy_erc20();
+    let nft = deploy_ip_nft_for(AUTHOR());
+    fund_and_approve(token, SPONSOR1(), sponsorship.contract_address, 250);
+
+    cheat_caller_address(sponsorship.contract_address, SPONSOR1(), CheatSpan::TargetCalls(1));
+    let proposal_id = sponsorship
+        .propose_sponsorship(
+            nft, IP_TOKEN, 250, DAY, token.contract_address, TERMS_URI(), true, 500,
+        );
+
+    cheat_caller_address(sponsorship.contract_address, AUTHOR(), CheatSpan::TargetCalls(1));
+    let license_id = sponsorship.accept_proposal(proposal_id);
+
+    let erc721 = IERC721Dispatcher { contract_address: license_nft.contract_address };
+    assert(erc721.owner_of(license_id) == SPONSOR1(), 'sponsor should hold license');
+    assert(token.balance_of(AUTHOR()) == 250, 'author should be paid');
+    assert(!sponsorship.get_proposal(proposal_id).open, 'proposal should be closed');
+}
+
+#[test]
+#[should_panic(expected: 'Not IP owner')]
+fn test_accept_proposal_reverts_for_non_owner() {
+    let (sponsorship, _) = deploy_sponsorship_pair();
+    let token = deploy_erc20();
+    let nft = deploy_ip_nft_for(AUTHOR());
+    fund_and_approve(token, SPONSOR1(), sponsorship.contract_address, 250);
+
+    cheat_caller_address(sponsorship.contract_address, SPONSOR1(), CheatSpan::TargetCalls(1));
+    let proposal_id = sponsorship
+        .propose_sponsorship(
+            nft, IP_TOKEN, 250, DAY, token.contract_address, TERMS_URI(), true, 0,
+        );
+
+    cheat_caller_address(sponsorship.contract_address, OUTSIDER(), CheatSpan::TargetCalls(1));
+    sponsorship.accept_proposal(proposal_id);
+}
+
+#[test]
+fn test_withdraw_proposal_closes_it() {
+    let (sponsorship, _) = deploy_sponsorship_pair();
+    let token = deploy_erc20();
+    let nft = deploy_ip_nft_for(AUTHOR());
+
+    cheat_caller_address(sponsorship.contract_address, SPONSOR1(), CheatSpan::TargetCalls(1));
+    let proposal_id = sponsorship
+        .propose_sponsorship(
+            nft, IP_TOKEN, 250, DAY, token.contract_address, TERMS_URI(), true, 0,
+        );
+    cheat_caller_address(sponsorship.contract_address, SPONSOR1(), CheatSpan::TargetCalls(1));
+    sponsorship.withdraw_proposal(proposal_id);
+
+    assert(!sponsorship.get_proposal(proposal_id).open, 'proposal should be closed');
+}
+
+#[test]
+#[should_panic(expected: 'Only proposer')]
+fn test_withdraw_proposal_rejects_non_proposer() {
+    let (sponsorship, _) = deploy_sponsorship_pair();
+    let token = deploy_erc20();
+    let nft = deploy_ip_nft_for(AUTHOR());
+
+    cheat_caller_address(sponsorship.contract_address, SPONSOR1(), CheatSpan::TargetCalls(1));
+    let proposal_id = sponsorship
+        .propose_sponsorship(
+            nft, IP_TOKEN, 250, DAY, token.contract_address, TERMS_URI(), true, 0,
+        );
+    cheat_caller_address(sponsorship.contract_address, OUTSIDER(), CheatSpan::TargetCalls(1));
+    sponsorship.withdraw_proposal(proposal_id);
+}
+
+#[test]
+fn test_reject_proposal_by_owner_closes_it() {
+    let (sponsorship, _) = deploy_sponsorship_pair();
+    let token = deploy_erc20();
+    let nft = deploy_ip_nft_for(AUTHOR());
+
+    cheat_caller_address(sponsorship.contract_address, SPONSOR1(), CheatSpan::TargetCalls(1));
+    let proposal_id = sponsorship
+        .propose_sponsorship(
+            nft, IP_TOKEN, 250, DAY, token.contract_address, TERMS_URI(), true, 0,
+        );
+    cheat_caller_address(sponsorship.contract_address, AUTHOR(), CheatSpan::TargetCalls(1));
+    sponsorship.reject_proposal(proposal_id);
+
+    assert(!sponsorship.get_proposal(proposal_id).open, 'proposal should be closed');
+}
+
+#[test]
+#[should_panic(expected: 'Proposal not open')]
+fn test_accept_proposal_reverts_after_withdrawal() {
+    let (sponsorship, _) = deploy_sponsorship_pair();
+    let token = deploy_erc20();
+    let nft = deploy_ip_nft_for(AUTHOR());
+    fund_and_approve(token, SPONSOR1(), sponsorship.contract_address, 250);
+
+    cheat_caller_address(sponsorship.contract_address, SPONSOR1(), CheatSpan::TargetCalls(1));
+    let proposal_id = sponsorship
+        .propose_sponsorship(
+            nft, IP_TOKEN, 250, DAY, token.contract_address, TERMS_URI(), true, 0,
+        );
+    cheat_caller_address(sponsorship.contract_address, SPONSOR1(), CheatSpan::TargetCalls(1));
+    sponsorship.withdraw_proposal(proposal_id);
+
+    cheat_caller_address(sponsorship.contract_address, AUTHOR(), CheatSpan::TargetCalls(1));
+    sponsorship.accept_proposal(proposal_id);
 }

--- a/contracts/IP-Sponsorhip/tests/test_contract.cairo
+++ b/contracts/IP-Sponsorhip/tests/test_contract.cairo
@@ -1,3 +1,6 @@
+use ip_sponsorship::IPSponsorship::IPSponsorship::{
+    Event as SponsorshipEvent, ProposalAccepted, ProposalClosed,
+};
 use ip_sponsorship::IPSponsorshipLicense::IPSponsorshipLicense::{Event, LicenseMinted};
 use ip_sponsorship::interface::{
     IIPSponsorshipDispatcher, IIPSponsorshipDispatcherTrait, IIPSponsorshipLicenseDispatcher,
@@ -717,7 +720,7 @@ fn test_propose_sponsorship_then_owner_accepts() {
     cheat_caller_address(sponsorship.contract_address, SPONSOR1(), CheatSpan::TargetCalls(1));
     let proposal_id = sponsorship
         .propose_sponsorship(
-            nft, IP_TOKEN, 250, DAY, token.contract_address, TERMS_URI(), true, 500,
+            nft, IP_TOKEN, 250, DAY, 0, token.contract_address, TERMS_URI(), true, 500,
         );
 
     cheat_caller_address(sponsorship.contract_address, AUTHOR(), CheatSpan::TargetCalls(1));
@@ -740,7 +743,7 @@ fn test_accept_proposal_reverts_for_non_owner() {
     cheat_caller_address(sponsorship.contract_address, SPONSOR1(), CheatSpan::TargetCalls(1));
     let proposal_id = sponsorship
         .propose_sponsorship(
-            nft, IP_TOKEN, 250, DAY, token.contract_address, TERMS_URI(), true, 0,
+            nft, IP_TOKEN, 250, DAY, 0, token.contract_address, TERMS_URI(), true, 0,
         );
 
     cheat_caller_address(sponsorship.contract_address, OUTSIDER(), CheatSpan::TargetCalls(1));
@@ -756,7 +759,7 @@ fn test_withdraw_proposal_closes_it() {
     cheat_caller_address(sponsorship.contract_address, SPONSOR1(), CheatSpan::TargetCalls(1));
     let proposal_id = sponsorship
         .propose_sponsorship(
-            nft, IP_TOKEN, 250, DAY, token.contract_address, TERMS_URI(), true, 0,
+            nft, IP_TOKEN, 250, DAY, 0, token.contract_address, TERMS_URI(), true, 0,
         );
     cheat_caller_address(sponsorship.contract_address, SPONSOR1(), CheatSpan::TargetCalls(1));
     sponsorship.withdraw_proposal(proposal_id);
@@ -774,7 +777,7 @@ fn test_withdraw_proposal_rejects_non_proposer() {
     cheat_caller_address(sponsorship.contract_address, SPONSOR1(), CheatSpan::TargetCalls(1));
     let proposal_id = sponsorship
         .propose_sponsorship(
-            nft, IP_TOKEN, 250, DAY, token.contract_address, TERMS_URI(), true, 0,
+            nft, IP_TOKEN, 250, DAY, 0, token.contract_address, TERMS_URI(), true, 0,
         );
     cheat_caller_address(sponsorship.contract_address, OUTSIDER(), CheatSpan::TargetCalls(1));
     sponsorship.withdraw_proposal(proposal_id);
@@ -789,7 +792,7 @@ fn test_reject_proposal_by_owner_closes_it() {
     cheat_caller_address(sponsorship.contract_address, SPONSOR1(), CheatSpan::TargetCalls(1));
     let proposal_id = sponsorship
         .propose_sponsorship(
-            nft, IP_TOKEN, 250, DAY, token.contract_address, TERMS_URI(), true, 0,
+            nft, IP_TOKEN, 250, DAY, 0, token.contract_address, TERMS_URI(), true, 0,
         );
     cheat_caller_address(sponsorship.contract_address, AUTHOR(), CheatSpan::TargetCalls(1));
     sponsorship.reject_proposal(proposal_id);
@@ -808,11 +811,227 @@ fn test_accept_proposal_reverts_after_withdrawal() {
     cheat_caller_address(sponsorship.contract_address, SPONSOR1(), CheatSpan::TargetCalls(1));
     let proposal_id = sponsorship
         .propose_sponsorship(
-            nft, IP_TOKEN, 250, DAY, token.contract_address, TERMS_URI(), true, 0,
+            nft, IP_TOKEN, 250, DAY, 0, token.contract_address, TERMS_URI(), true, 0,
         );
     cheat_caller_address(sponsorship.contract_address, SPONSOR1(), CheatSpan::TargetCalls(1));
     sponsorship.withdraw_proposal(proposal_id);
 
     cheat_caller_address(sponsorship.contract_address, AUTHOR(), CheatSpan::TargetCalls(1));
     sponsorship.accept_proposal(proposal_id);
+}
+
+fn propose(
+    sponsorship: IIPSponsorshipDispatcher, nft: ContractAddress, token: ContractAddress,
+) -> u256 {
+    cheat_caller_address(sponsorship.contract_address, SPONSOR1(), CheatSpan::TargetCalls(1));
+    sponsorship.propose_sponsorship(nft, IP_TOKEN, 250, DAY, 0, token, TERMS_URI(), true, 0)
+}
+
+#[test]
+#[should_panic(expected: 'Not IP owner')]
+fn test_reject_proposal_rejects_non_owner() {
+    let (sponsorship, _) = deploy_sponsorship_pair();
+    let token = deploy_erc20();
+    let nft = deploy_ip_nft_for(AUTHOR());
+    let proposal_id = propose(sponsorship, nft, token.contract_address);
+
+    cheat_caller_address(sponsorship.contract_address, OUTSIDER(), CheatSpan::TargetCalls(1));
+    sponsorship.reject_proposal(proposal_id);
+}
+
+#[test]
+#[should_panic(expected: 'Proposal not open')]
+fn test_accept_proposal_reverts_after_reject() {
+    let (sponsorship, _) = deploy_sponsorship_pair();
+    let token = deploy_erc20();
+    let nft = deploy_ip_nft_for(AUTHOR());
+    fund_and_approve(token, SPONSOR1(), sponsorship.contract_address, 250);
+    let proposal_id = propose(sponsorship, nft, token.contract_address);
+
+    cheat_caller_address(sponsorship.contract_address, AUTHOR(), CheatSpan::TargetCalls(1));
+    sponsorship.reject_proposal(proposal_id);
+
+    cheat_caller_address(sponsorship.contract_address, AUTHOR(), CheatSpan::TargetCalls(1));
+    sponsorship.accept_proposal(proposal_id);
+}
+
+#[test]
+#[should_panic(expected: 'Proposal not open')]
+fn test_withdraw_proposal_reverts_after_accept() {
+    let (sponsorship, _) = deploy_sponsorship_pair();
+    let token = deploy_erc20();
+    let nft = deploy_ip_nft_for(AUTHOR());
+    fund_and_approve(token, SPONSOR1(), sponsorship.contract_address, 250);
+    let proposal_id = propose(sponsorship, nft, token.contract_address);
+
+    cheat_caller_address(sponsorship.contract_address, AUTHOR(), CheatSpan::TargetCalls(1));
+    sponsorship.accept_proposal(proposal_id);
+
+    cheat_caller_address(sponsorship.contract_address, SPONSOR1(), CheatSpan::TargetCalls(1));
+    sponsorship.withdraw_proposal(proposal_id);
+}
+
+#[test]
+#[should_panic(expected: 'Amount cannot be zero')]
+fn test_propose_rejects_zero_amount() {
+    let (sponsorship, _) = deploy_sponsorship_pair();
+    let token = deploy_erc20();
+    let nft = deploy_ip_nft_for(AUTHOR());
+
+    cheat_caller_address(sponsorship.contract_address, SPONSOR1(), CheatSpan::TargetCalls(1));
+    sponsorship
+        .propose_sponsorship(
+            nft, IP_TOKEN, 0, DAY, 0, token.contract_address, TERMS_URI(), true, 0,
+        );
+}
+
+#[test]
+#[should_panic(expected: 'Duration cannot be zero')]
+fn test_propose_rejects_zero_duration() {
+    let (sponsorship, _) = deploy_sponsorship_pair();
+    let token = deploy_erc20();
+    let nft = deploy_ip_nft_for(AUTHOR());
+
+    cheat_caller_address(sponsorship.contract_address, SPONSOR1(), CheatSpan::TargetCalls(1));
+    sponsorship
+        .propose_sponsorship(
+            nft, IP_TOKEN, 250, 0, 0, token.contract_address, TERMS_URI(), true, 0,
+        );
+}
+
+#[test]
+#[should_panic(expected: 'URI must be ipfs:// or ar://')]
+fn test_propose_rejects_http_terms() {
+    let (sponsorship, _) = deploy_sponsorship_pair();
+    let token = deploy_erc20();
+    let nft = deploy_ip_nft_for(AUTHOR());
+
+    cheat_caller_address(sponsorship.contract_address, SPONSOR1(), CheatSpan::TargetCalls(1));
+    sponsorship
+        .propose_sponsorship(
+            nft, IP_TOKEN, 250, DAY, 0, token.contract_address, HTTP_URI(), true, 0,
+        );
+}
+
+#[test]
+#[should_panic(expected: 'Royalty exceeds 10000')]
+fn test_propose_rejects_bad_royalty() {
+    let (sponsorship, _) = deploy_sponsorship_pair();
+    let token = deploy_erc20();
+    let nft = deploy_ip_nft_for(AUTHOR());
+
+    cheat_caller_address(sponsorship.contract_address, SPONSOR1(), CheatSpan::TargetCalls(1));
+    sponsorship
+        .propose_sponsorship(
+            nft, IP_TOKEN, 250, DAY, 0, token.contract_address, TERMS_URI(), true, 10_001,
+        );
+}
+
+#[test]
+#[should_panic(expected: 'Deadline in the past')]
+fn test_propose_rejects_past_deadline() {
+    let (sponsorship, _) = deploy_sponsorship_pair();
+    let token = deploy_erc20();
+    let nft = deploy_ip_nft_for(AUTHOR());
+
+    cheat_block_timestamp(sponsorship.contract_address, 500, CheatSpan::TargetCalls(1));
+    cheat_caller_address(sponsorship.contract_address, SPONSOR1(), CheatSpan::TargetCalls(1));
+    sponsorship
+        .propose_sponsorship(
+            nft, IP_TOKEN, 250, DAY, 400, token.contract_address, TERMS_URI(), true, 0,
+        );
+}
+
+#[test]
+#[should_panic(expected: 'Proposal expired')]
+fn test_accept_proposal_reverts_after_deadline() {
+    let (sponsorship, _) = deploy_sponsorship_pair();
+    let token = deploy_erc20();
+    let nft = deploy_ip_nft_for(AUTHOR());
+    fund_and_approve(token, SPONSOR1(), sponsorship.contract_address, 250);
+
+    cheat_caller_address(sponsorship.contract_address, SPONSOR1(), CheatSpan::TargetCalls(1));
+    let proposal_id = sponsorship
+        .propose_sponsorship(
+            nft, IP_TOKEN, 250, DAY, 1000, token.contract_address, TERMS_URI(), true, 0,
+        );
+
+    cheat_block_timestamp(sponsorship.contract_address, 1001, CheatSpan::TargetCalls(1));
+    cheat_caller_address(sponsorship.contract_address, AUTHOR(), CheatSpan::TargetCalls(1));
+    sponsorship.accept_proposal(proposal_id);
+}
+
+#[test]
+#[should_panic]
+fn test_accept_proposal_without_allowance_reverts_atomically() {
+    let (sponsorship, _) = deploy_sponsorship_pair();
+    let token = deploy_erc20();
+    let nft = deploy_ip_nft_for(AUTHOR());
+    // Proposer never approved — the proposer's de-facto withdrawal path.
+    let proposal_id = propose(sponsorship, nft, token.contract_address);
+
+    cheat_caller_address(sponsorship.contract_address, AUTHOR(), CheatSpan::TargetCalls(1));
+    sponsorship.accept_proposal(proposal_id);
+}
+
+#[test]
+fn test_new_owner_can_accept_proposal_after_ip_sale() {
+    // A proposal binds to the asset, not a person: whoever owns the asset
+    // at acceptance time is paid and issues the license.
+    let (sponsorship, license_nft) = deploy_sponsorship_pair();
+    let token = deploy_erc20();
+    let nft = deploy_ip_nft_for(AUTHOR());
+    fund_and_approve(token, SPONSOR1(), sponsorship.contract_address, 250);
+    let proposal_id = propose(sponsorship, nft, token.contract_address);
+
+    let ip = IERC721Dispatcher { contract_address: nft };
+    cheat_caller_address(nft, AUTHOR(), CheatSpan::TargetCalls(1));
+    ip.transfer_from(AUTHOR(), SPONSOR2(), IP_TOKEN);
+
+    cheat_caller_address(sponsorship.contract_address, SPONSOR2(), CheatSpan::TargetCalls(1));
+    let license_id = sponsorship.accept_proposal(proposal_id);
+
+    assert(token.balance_of(SPONSOR2()) == 250, 'new owner should be paid');
+    let erc721 = IERC721Dispatcher { contract_address: license_nft.contract_address };
+    assert(erc721.owner_of(license_id) == SPONSOR1(), 'sponsor should hold license');
+    assert(sponsorship.get_license(license_id).author == SPONSOR2(), 'license author is new owner');
+}
+
+#[test]
+fn test_accept_proposal_emits_closed_and_accepted() {
+    let (sponsorship, _) = deploy_sponsorship_pair();
+    let token = deploy_erc20();
+    let nft = deploy_ip_nft_for(AUTHOR());
+    fund_and_approve(token, SPONSOR1(), sponsorship.contract_address, 250);
+    let proposal_id = propose(sponsorship, nft, token.contract_address);
+
+    cheat_block_timestamp(sponsorship.contract_address, 1000, CheatSpan::TargetCalls(1));
+    cheat_caller_address(sponsorship.contract_address, AUTHOR(), CheatSpan::TargetCalls(1));
+    let mut spy = spy_events();
+    let license_id = sponsorship.accept_proposal(proposal_id);
+
+    spy
+        .assert_emitted(
+            @array![
+                (
+                    sponsorship.contract_address,
+                    SponsorshipEvent::ProposalClosed(
+                        ProposalClosed { proposal_id, accepted: true, closed_at: 1000 },
+                    ),
+                ),
+                (
+                    sponsorship.contract_address,
+                    SponsorshipEvent::ProposalAccepted(
+                        ProposalAccepted {
+                            proposal_id,
+                            license_id,
+                            sponsor: SPONSOR1(),
+                            author: AUTHOR(),
+                            amount: 250,
+                            expires_at: 1000 + DAY,
+                        },
+                    ),
+                ),
+            ],
+        );
 }


### PR DESCRIPTION
## Summary
- Drops `IPSponsorshipLicense`'s hard on-chain transfer/expiry enforcement — transferability and expiry become declarative terms (read via `is_license_valid()`, never gating a transfer), matching the platform's soft-by-default licensing model. The atomic accept-and-mint guarantee (sponsor is certain to receive a real asset the instant they pay) is kept.
- Adds symmetric initiation: `propose_sponsorship` / `withdraw_proposal` / `accept_proposal` / `reject_proposal` let a sponsor propose terms on an asset with no open offer yet, mirroring the existing owner-initiated `create_offer` / `accept_bid` flow. Both accept paths share one `settle_and_mint` internal helper.
- Bumps both contracts to `version() == "3.0.0"` with fresh SRC5 discovery IDs.

Design doc: `medialane-core/docs/specs/2026-07-14-ip-sponsorship-real-world-redesign-design.md`
Implementation plan: `medialane-core/docs/plans/2026-07-14-ip-sponsorship-real-world-redesign.md`

**This is Stage A of that plan only** — contract changes for external review. Not deployed. SDK/backend/UI stages follow after this review and an authorized deploy.

## Test plan
- [x] `scarb build` clean
- [x] `snforge test` — 38/38 passing
- [ ] External review of this diff
- [ ] Declare + deploy on explicit authorization (separate step, not part of this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)