### PR TITLE
IPClubCollection v3: standard per-token metadata

### DIFF
--- a/contracts/IP-Club/src/IPClubCollection.cairo
+++ b/contracts/IP-Club/src/IPClubCollection.cairo
@@ -1,10 +1,8 @@
-// IPClubCollection — per-creator ERC-721 membership contract deployed by
-// IPClubFactory. Public mint; fee flows directly creator → buyer in the call.
-// Standard per-token metadata: token_uri = base_uri + token_id, so base_uri
-// is a content-addressed directory (must end with '/') holding one document
-// per card — uniform cards, serials, or tiers are all the creator's choice.
-// Fully immutable: no metadata update, no supply change, no admin backdoors.
-// Ownable only for set_open (creator-managed pause on new memberships).
+// IPClubCollection — per-creator ERC-721 membership collection deployed by
+// IPClubFactory. Anyone may mint; the entry fee settles payer → owner
+// directly. token_uri = base_uri + token_id over a content-addressed
+// directory. No metadata update, no supply change, no admin surface beyond
+// set_open.
 
 #[starknet::contract]
 pub mod IPClubCollection {
@@ -49,15 +47,10 @@ pub mod IPClubCollection {
         src5: SRC5Component::Storage,
         #[substorage(v0)]
         ownable: OwnableComponent::Storage,
-        /// Hard cap on membership supply. Immutable.
         club_max_supply: u256,
-        /// Entry fee per membership in payment_token base units. Immutable.
         club_entry_fee: u256,
-        /// ERC-20 accepted for entry fees. None means free. Immutable.
         club_payment_token: Option<ContractAddress>,
-        /// EIP-2981 royalty in basis points (0..=10000). Immutable.
         club_royalty_bps: u256,
-        /// Creator-controlled gate on new mints. Does not affect existing members.
         club_is_open: bool,
         next_token_id: u256,
     }
@@ -106,8 +99,6 @@ pub mod IPClubCollection {
         let valid_uri = bytearray_starts_with(@base_uri, @"ipfs://")
             || bytearray_starts_with(@base_uri, @"ar://");
         assert(valid_uri, 'URI must be ipfs:// or ar://');
-        // token_uri = base_uri + token_id, so the directory separator must
-        // already be present or every card's URI dangles permanently.
         assert(bytearray_ends_with(@base_uri, @"/"), 'Base URI must end with /');
         assert(max_supply > 0, 'Max supply must be > 0');
         assert(royalty_bps <= 10000, 'Royalty exceeds 10000');
@@ -140,7 +131,6 @@ pub mod IPClubCollection {
 
             let payer = get_caller_address();
 
-            // Effects before external calls (checks-effects-interactions).
             let token_id = self.next_token_id.read();
             assert(token_id <= self.club_max_supply.read(), 'Max supply reached');
             self.next_token_id.write(token_id + 1);
@@ -207,7 +197,7 @@ pub mod IPClubCollection {
         }
 
         fn version(self: @ContractState) -> ByteArray {
-            "2.0.0"
+            "3.0.0"
         }
     }
 }

--- a/contracts/IP-Club/src/IPClubCollection.cairo
+++ b/contracts/IP-Club/src/IPClubCollection.cairo
@@ -1,5 +1,8 @@
 // IPClubCollection — per-creator ERC-721 membership contract deployed by
 // IPClubFactory. Public mint; fee flows directly creator → buyer in the call.
+// Standard per-token metadata: token_uri = base_uri + token_id, so base_uri
+// is a content-addressed directory (must end with '/') holding one document
+// per card — uniform cards, serials, or tiers are all the creator's choice.
 // Fully immutable: no metadata update, no supply change, no admin backdoors.
 // Ownable only for set_open (creator-managed pause on new memberships).
 
@@ -10,12 +13,11 @@ pub mod IPClubCollection {
     use openzeppelin_introspection::src5::SRC5Component;
     use openzeppelin_token::common::erc2981::interface::IERC2981_ID;
     use openzeppelin_token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
-    use openzeppelin_token::erc721::ERC721Component;
-    use openzeppelin_token::erc721::interface::{IERC721Metadata, IERC721MetadataCamelOnly};
+    use openzeppelin_token::erc721::{ERC721Component, ERC721HooksEmptyImpl};
     use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
     use starknet::{ContractAddress, get_caller_address};
     use crate::interface::{IIPClubCollection, IIP_CLUB_COLLECTION_ID};
-    use crate::types::bytearray_starts_with;
+    use crate::types::{bytearray_ends_with, bytearray_starts_with};
 
     component!(path: ERC721Component, storage: erc721, event: ERC721Event);
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
@@ -25,6 +27,11 @@ pub mod IPClubCollection {
     impl ERC721Impl = ERC721Component::ERC721Impl<ContractState>;
     #[abi(embed_v0)]
     impl ERC721CamelOnly = ERC721Component::ERC721CamelOnlyImpl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC721MetadataImpl = ERC721Component::ERC721MetadataImpl<ContractState>;
+    #[abi(embed_v0)]
+    impl ERC721MetadataCamelOnlyImpl =
+        ERC721Component::ERC721MetadataCamelOnlyImpl<ContractState>;
     #[abi(embed_v0)]
     impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
     #[abi(embed_v0)]
@@ -42,8 +49,6 @@ pub mod IPClubCollection {
         src5: SRC5Component::Storage,
         #[substorage(v0)]
         ownable: OwnableComponent::Storage,
-        /// Immutable collection metadata URI (ipfs:// or ar://).
-        club_base_uri: ByteArray,
         /// Hard cap on membership supply. Immutable.
         club_max_supply: u256,
         /// Entry fee per membership in payment_token base units. Immutable.
@@ -55,7 +60,6 @@ pub mod IPClubCollection {
         /// Creator-controlled gate on new mints. Does not affect existing members.
         club_is_open: bool,
         next_token_id: u256,
-        club_total_minted: u256,
     }
 
     #[event]
@@ -102,6 +106,9 @@ pub mod IPClubCollection {
         let valid_uri = bytearray_starts_with(@base_uri, @"ipfs://")
             || bytearray_starts_with(@base_uri, @"ar://");
         assert(valid_uri, 'URI must be ipfs:// or ar://');
+        // token_uri = base_uri + token_id, so the directory separator must
+        // already be present or every card's URI dangles permanently.
+        assert(bytearray_ends_with(@base_uri, @"/"), 'Base URI must end with /');
         assert(max_supply > 0, 'Max supply must be > 0');
         assert(royalty_bps <= 10000, 'Royalty exceeds 10000');
         assert(!owner.is_zero(), 'Owner is zero address');
@@ -112,12 +119,11 @@ pub mod IPClubCollection {
             assert(!payment_token.unwrap().is_zero(), 'Payment token is zero');
         }
 
-        self.erc721.initializer(name, symbol, "");
+        self.erc721.initializer(name, symbol, base_uri);
         self.ownable.initializer(owner);
         self.src5.register_interface(IIP_CLUB_COLLECTION_ID);
         self.src5.register_interface(IERC2981_ID);
 
-        self.club_base_uri.write(base_uri);
         self.club_max_supply.write(max_supply);
         self.club_entry_fee.write(entry_fee);
         self.club_payment_token.write(payment_token);
@@ -126,59 +132,18 @@ pub mod IPClubCollection {
         self.next_token_id.write(1);
     }
 
-    impl ERC721HooksImpl of ERC721Component::ERC721HooksTrait<ContractState> {
-        fn before_update(
-            ref self: ERC721Component::ComponentState<ContractState>,
-            to: ContractAddress,
-            token_id: u256,
-            auth: ContractAddress,
-        ) {}
-
-        fn after_update(
-            ref self: ERC721Component::ComponentState<ContractState>,
-            to: ContractAddress,
-            token_id: u256,
-            auth: ContractAddress,
-        ) {}
-    }
-
-    #[abi(embed_v0)]
-    impl ERC721MetadataImpl of IERC721Metadata<ContractState> {
-        fn name(self: @ContractState) -> ByteArray {
-            self.erc721.ERC721_name.read()
-        }
-
-        fn symbol(self: @ContractState) -> ByteArray {
-            self.erc721.ERC721_symbol.read()
-        }
-
-        fn token_uri(self: @ContractState, token_id: u256) -> ByteArray {
-            self.erc721._require_owned(token_id);
-            self.club_base_uri.read()
-        }
-    }
-
-    #[abi(embed_v0)]
-    impl ERC721MetadataCamelOnlyImpl of IERC721MetadataCamelOnly<ContractState> {
-        fn tokenURI(self: @ContractState, tokenId: u256) -> ByteArray {
-            self.erc721._require_owned(tokenId);
-            self.club_base_uri.read()
-        }
-    }
-
     #[abi(embed_v0)]
     pub impl IPClubCollectionImpl of IIPClubCollection<ContractState> {
         fn mint(ref self: ContractState, to: ContractAddress) -> u256 {
             assert(self.club_is_open.read(), 'Club is closed');
-            assert(self.club_total_minted.read() < self.club_max_supply.read(), 'Max supply reached');
             assert(!to.is_zero(), 'Recipient is zero address');
 
             let payer = get_caller_address();
 
             // Effects before external calls (checks-effects-interactions).
             let token_id = self.next_token_id.read();
+            assert(token_id <= self.club_max_supply.read(), 'Max supply reached');
             self.next_token_id.write(token_id + 1);
-            self.club_total_minted.write(self.club_total_minted.read() + 1);
 
             let fee = self.club_entry_fee.read();
             if fee > 0 {
@@ -203,7 +168,7 @@ pub mod IPClubCollection {
         }
 
         fn base_uri(self: @ContractState) -> ByteArray {
-            self.club_base_uri.read()
+            self.erc721.ERC721_base_uri.read()
         }
 
         fn entry_fee(self: @ContractState) -> u256 {
@@ -219,7 +184,7 @@ pub mod IPClubCollection {
         }
 
         fn total_minted(self: @ContractState) -> u256 {
-            self.club_total_minted.read()
+            self.next_token_id.read() - 1
         }
 
         fn is_open(self: @ContractState) -> bool {
@@ -238,14 +203,11 @@ pub mod IPClubCollection {
         fn royaltyInfo(
             self: @ContractState, token_id: u256, sale_price: u256,
         ) -> (ContractAddress, u256) {
-            self.erc721._require_owned(token_id);
-            let owner = self.ownable.owner();
-            let amount = (sale_price * self.club_royalty_bps.read()) / 10000;
-            (owner, amount)
+            self.royalty_info(token_id, sale_price)
         }
 
         fn version(self: @ContractState) -> ByteArray {
-            "1.0.0"
+            "2.0.0"
         }
     }
 }

--- a/contracts/IP-Club/src/IPClubFactory.cairo
+++ b/contracts/IP-Club/src/IPClubFactory.cairo
@@ -1,6 +1,5 @@
 // IPClubFactory — ownerless, immutable deploy point for IPClubCollection
 // contracts. Anyone can deploy a new club; the caller becomes its owner.
-// Mirrors IPTicketCollectionFactory.
 
 #[starknet::contract]
 pub mod IPClubFactory {
@@ -22,9 +21,7 @@ pub mod IPClubFactory {
     struct Storage {
         #[substorage(v0)]
         src5: SRC5Component::Storage,
-        /// Class hash of IPClubCollection. Fixed at deploy time.
         ip_club_collection_class_hash: ClassHash,
-        /// Monotonically incrementing nonce for unique deploy salts.
         deploy_nonce: felt252,
     }
 
@@ -36,7 +33,6 @@ pub mod IPClubFactory {
         ClubDeployed: ClubDeployed,
     }
 
-    /// Emitted each time a new IPClubCollection is deployed via `deploy_club`.
     #[derive(Drop, starknet::Event)]
     pub struct ClubDeployed {
         #[key]

--- a/contracts/IP-Club/src/interface.cairo
+++ b/contracts/IP-Club/src/interface.cairo
@@ -1,8 +1,8 @@
 use starknet::{ClassHash, ContractAddress};
 
-// starknet_keccak("mediolano.ip-club-collection.v1")
+// starknet_keccak("mediolano.ip-club-collection.v2")
 pub const IIP_CLUB_COLLECTION_ID: felt252 =
-    0x9aea52383b2d5a85aa88ae05b8f707032cf040d4236753956cad946abfcc77;
+    0x112f516c4cd5a5095db9a2e20c7fc3ac94631976965acd345652f01a29c1d40;
 
 // starknet_keccak("mediolano.ip-club-factory.v1")
 pub const IIP_CLUB_FACTORY_ID: felt252 =

--- a/contracts/IP-Club/src/interface.cairo
+++ b/contracts/IP-Club/src/interface.cairo
@@ -1,8 +1,8 @@
 use starknet::{ClassHash, ContractAddress};
 
-// starknet_keccak("mediolano.ip-club-collection.v2")
+// starknet_keccak("mediolano.ip-club-collection.v3")
 pub const IIP_CLUB_COLLECTION_ID: felt252 =
-    0x112f516c4cd5a5095db9a2e20c7fc3ac94631976965acd345652f01a29c1d40;
+    0x4b7aad07052a830d89731d485a019e4035c06a1699b800a0e74f732e8158ad;
 
 // starknet_keccak("mediolano.ip-club-factory.v1")
 pub const IIP_CLUB_FACTORY_ID: felt252 =

--- a/contracts/IP-Club/src/types.cairo
+++ b/contracts/IP-Club/src/types.cairo
@@ -1,3 +1,22 @@
+pub fn bytearray_ends_with(haystack: @ByteArray, needle: @ByteArray) -> bool {
+    let n = needle.len();
+    let h = haystack.len();
+    if h < n {
+        return false;
+    }
+    let offset = h - n;
+    let mut i: u32 = 0;
+    let mut matches = true;
+    while i < n {
+        if haystack.at(offset + i).unwrap() != needle.at(i).unwrap() {
+            matches = false;
+            break;
+        }
+        i += 1;
+    }
+    matches
+}
+
 pub fn bytearray_starts_with(haystack: @ByteArray, needle: @ByteArray) -> bool {
     let n = needle.len();
     if haystack.len() < n {

--- a/contracts/IP-Club/tests/test_IPClub.cairo
+++ b/contracts/IP-Club/tests/test_IPClub.cairo
@@ -135,7 +135,7 @@ fn test_collection_rejects_http_uri() {
 fn test_collection_version() {
     let TestContracts = setup();
     let club = deploy_free_club(TestContracts.factory, CREATOR());
-    assert!(club.version() == "2.0.0", "collection version");
+    assert!(club.version() == "3.0.0", "collection version");
 }
 
 #[test]

--- a/contracts/IP-Club/tests/test_IPClub.cairo
+++ b/contracts/IP-Club/tests/test_IPClub.cairo
@@ -15,7 +15,8 @@ use crate::utils::{
     deploy_reentrant_payment_token, mint_erc20, setup,
 };
 
-// ── Factory ─────────────────────────────────────────────────────────────────
+// ── Factory
+// ─────────────────────────────────────────────────────────────────
 
 #[test]
 fn test_factory_version() {
@@ -64,17 +65,22 @@ fn test_two_clubs_get_different_addresses() {
 #[should_panic(expected: 'Name must not be empty')]
 fn test_factory_rejects_empty_name() {
     let TestContracts = setup();
-    TestContracts.factory.deploy_club("", "VPS", IPFS_URI(), 100_u256, 0_u256, Option::None, 0_u256);
+    TestContracts
+        .factory
+        .deploy_club("", "VPS", IPFS_URI(), 100_u256, 0_u256, Option::None, 0_u256);
 }
 
 #[test]
 #[should_panic(expected: 'Symbol must not be empty')]
 fn test_factory_rejects_empty_symbol() {
     let TestContracts = setup();
-    TestContracts.factory.deploy_club("Vipers", "", IPFS_URI(), 100_u256, 0_u256, Option::None, 0_u256);
+    TestContracts
+        .factory
+        .deploy_club("Vipers", "", IPFS_URI(), 100_u256, 0_u256, Option::None, 0_u256);
 }
 
-// ── Collection basics ────────────────────────────────────────────────────────
+// ── Collection basics
+// ────────────────────────────────────────────────────────
 
 #[test]
 fn test_collection_name_symbol() {
@@ -115,7 +121,13 @@ fn test_collection_rejects_http_uri() {
     TestContracts
         .factory
         .deploy_club(
-            "Vipers", "VPS", "https://example.com/club.json", 100_u256, 0_u256, Option::None, 0_u256,
+            "Vipers",
+            "VPS",
+            "https://example.com/club.json",
+            100_u256,
+            0_u256,
+            Option::None,
+            0_u256,
         );
 }
 
@@ -123,7 +135,7 @@ fn test_collection_rejects_http_uri() {
 fn test_collection_version() {
     let TestContracts = setup();
     let club = deploy_free_club(TestContracts.factory, CREATOR());
-    assert!(club.version() == "1.0.0", "collection version");
+    assert!(club.version() == "2.0.0", "collection version");
 }
 
 #[test]
@@ -146,7 +158,8 @@ fn test_collection_initial_state() {
     assert!(club.payment_token().is_none(), "no payment token");
 }
 
-// ── Mint (free) ──────────────────────────────────────────────────────────────
+// ── Mint (free)
+// ──────────────────────────────────────────────────────────────
 
 #[test]
 fn test_mint_free_membership() {
@@ -214,7 +227,8 @@ fn test_mint_to_non_receiver_contract_reverts() {
     club.mint(TestContracts.factory.contract_address);
 }
 
-// ── Supply cap ───────────────────────────────────────────────────────────────
+// ── Supply cap
+// ───────────────────────────────────────────────────────────────
 
 #[test]
 #[should_panic(expected: 'Max supply reached')]
@@ -249,7 +263,8 @@ fn test_deploy_club_rejects_zero_supply() {
         .deploy_club("Vipers", "VPS", IPFS_URI(), 0_u256, 0_u256, Option::None, 0_u256);
 }
 
-// ── set_open ─────────────────────────────────────────────────────────────────
+// ── set_open
+// ─────────────────────────────────────────────────────────────────
 
 #[test]
 fn test_set_open_closes_and_reopens() {
@@ -289,7 +304,8 @@ fn test_only_owner_can_set_open() {
     club.set_open(false);
 }
 
-// ── Paid membership ──────────────────────────────────────────────────────────
+// ── Paid membership
+// ──────────────────────────────────────────────────────────
 
 #[test]
 fn test_mint_with_entry_fee() {
@@ -367,17 +383,12 @@ fn test_paid_club_rejects_zero_payment_token() {
     TestContracts
         .factory
         .deploy_club(
-            "Vipers",
-            "VPS",
-            IPFS_URI(),
-            100_u256,
-            1000_u256,
-            Option::Some(ZERO_ADDRESS()),
-            0_u256,
+            "Vipers", "VPS", IPFS_URI(), 100_u256, 1000_u256, Option::Some(ZERO_ADDRESS()), 0_u256,
         );
 }
 
-// ── Royalties ────────────────────────────────────────────────────────────────
+// ── Royalties
+// ────────────────────────────────────────────────────────────────
 
 #[test]
 fn test_royalty_info() {
@@ -411,22 +422,63 @@ fn test_royalty_bps_capped() {
         .deploy_club("Vipers", "VPS", IPFS_URI(), 100_u256, 0_u256, Option::None, 10001_u256);
 }
 
-// ── token_uri ────────────────────────────────────────────────────────────────
+// ── token_uri
+// ────────────────────────────────────────────────────────────────
 
 #[test]
-fn test_token_uri_returns_base_uri() {
+fn test_token_uri_is_per_token() {
     let TestContracts = setup();
     let club = deploy_free_club(TestContracts.factory, CREATOR());
     let member = deploy_receiver();
 
     cheat_caller_address(club.contract_address, member, CheatSpan::TargetCalls(1));
-    let token_id = club.mint(member);
+    let t1 = club.mint(member);
+    cheat_caller_address(club.contract_address, member, CheatSpan::TargetCalls(1));
+    let t2 = club.mint(member);
 
     let meta = IERC721MetadataDispatcher { contract_address: club.contract_address };
-    assert!(meta.token_uri(token_id) == IPFS_URI(), "token_uri == base_uri");
+    assert!(meta.token_uri(t1) == "ipfs://bafybeiclubmetadata/1", "token 1 uri");
+    assert!(meta.token_uri(t2) == "ipfs://bafybeiclubmetadata/2", "token 2 uri");
 }
 
-// ── Reentrancy ───────────────────────────────────────────────────────────────
+#[test]
+#[should_panic(expected: 'Base URI must end with /')]
+fn test_deploy_rejects_uri_without_trailing_slash() {
+    let TestContracts = setup();
+    cheat_caller_address(
+        TestContracts.factory.contract_address, CREATOR(), CheatSpan::TargetCalls(1),
+    );
+    TestContracts
+        .factory
+        .deploy_club(
+            "Vipers", "VPS", "ipfs://bafybeiclubmetadata", 100_u256, 0_u256, Option::None, 0_u256,
+        );
+}
+
+// ── Transferability
+// ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_membership_card_transfers_like_standard_erc721() {
+    let TestContracts = setup();
+    let club = deploy_free_club(TestContracts.factory, CREATOR());
+    let member = deploy_receiver();
+    let buyer = deploy_receiver();
+
+    cheat_caller_address(club.contract_address, member, CheatSpan::TargetCalls(1));
+    let token_id = club.mint(member);
+
+    let erc721 = IERC721Dispatcher { contract_address: club.contract_address };
+    cheat_caller_address(club.contract_address, member, CheatSpan::TargetCalls(1));
+    erc721.transfer_from(member, buyer, token_id);
+
+    assert!(erc721.owner_of(token_id) == buyer, "buyer holds the card");
+    assert!(erc721.balance_of(member) == 0, "seller no longer a member");
+    assert!(erc721.balance_of(buyer) == 1, "membership moved with the card");
+}
+
+// ── Reentrancy
+// ───────────────────────────────────────────────────────────────
 
 // A reentrant payment token attempting to call mint() from within transfer_from
 // runs under the reentrant token's caller context. It will fail because
@@ -447,9 +499,7 @@ fn test_reentrant_payment_token_reverts_atomically() {
     let placeholder: starknet::ContractAddress = 0x999.try_into().unwrap();
     let addr = TestContracts
         .factory
-        .deploy_club(
-            "Vipers", "VPS", IPFS_URI(), 100_u256, fee, Option::Some(placeholder), 0_u256,
-        );
+        .deploy_club("Vipers", "VPS", IPFS_URI(), 100_u256, fee, Option::Some(placeholder), 0_u256);
     let reentrant_token = deploy_reentrant_payment_token(addr, reentry_target);
 
     // Re-deploy with the reentrant token (need a second club).

--- a/contracts/IP-Club/tests/utils.cairo
+++ b/contracts/IP-Club/tests/utils.cairo
@@ -20,11 +20,11 @@ pub fn ZERO_ADDRESS() -> ContractAddress {
 }
 
 pub fn IPFS_URI() -> ByteArray {
-    "ipfs://bafybeiclubmetadata"
+    "ipfs://bafybeiclubmetadata/"
 }
 
 pub fn AR_URI() -> ByteArray {
-    "ar://club-metadata"
+    "ar://club-metadata/"
 }
 
 pub fn declare_and_deploy(contract_name: ByteArray, calldata: Array<felt252>) -> ContractAddress {


### PR DESCRIPTION
## Summary
- Replaces the shared-document metadata model with standard ERC-721 per-token URIs: `token_uri = base_uri + token_id` (OZ default composition). `base_uri` must be a content-addressed directory ending in `/` — enforced at deploy so no club can ever ship dangling URIs.
- Cards in one club can now differ (serials, tiers, per-card artwork); a creator who wants uniform cards pins identical documents.
- Collection is `version() == "3.0.0"` with a fresh SRC5 ID (`mediolano.ip-club-collection.v3`). Factory code unchanged.
- Production comment pass: source carries only constraint-bearing comments.
- Internal cleanups bundled with the class revision: `royaltyInfo` delegates to `royalty_info`, minted counter derived from `next_token_id`, OZ `ERC721HooksEmptyImpl`.

Contract changes only — not deployed. Declare/deploy and the SDK/app updates (new `ipClubCollectionClassHash`, factory redeploy, directory-pinning create flow) follow separately.

## Test plan
- [x] `scarb build` clean
- [x] `snforge test` — 33/33 passing (new: per-token URI, trailing-slash revert, standard-transfer membership)
- [ ] Declare + deploy on explicit authorization

🤖 Generated with [Claude Code](https://claude.com/claude-code)